### PR TITLE
Add default NATS port to spec file

### DIFF
--- a/jobs/cpi/spec
+++ b/jobs/cpi/spec
@@ -84,4 +84,5 @@ properties:
     description: NATS address used by agent to subscribe to agent requests
   nats.port:
     description: NATS port used by agent to subscribe to agent requests
+    default: 4222
 


### PR DESCRIPTION
I tried to use manifest from [bosh.io docs](http://bosh.io/docs/init-openstack.html), but I got an error that said that I didn't specified `nats.port` option. After some investigation I found out that the reason is that [bosh-director](https://github.com/cloudfoundry/bosh/blob/master/release/jobs/director/spec#L120) has a default value for this option, but [bosh-openstack-cpi-release doesn't](https://github.com/cloudfoundry-incubator/bosh-openstack-cpi-release/blob/master/jobs/cpi/spec#L85). This PR fixes it.

Thank you,
Alex L.