### PR TITLE
Restrict to run vendor_gems script with wrong version of bundler.

### DIFF
--- a/scripts/vendor_gems
+++ b/scripts/vendor_gems
@@ -2,6 +2,11 @@
 
 set -ex
 
+if [[ "`bundle --version`" != *"1.8.2"* ]]; then
+  echo "You should use bundler with version 1.8.2"
+  exit 2
+fi
+
 cpi_name="openstack"
 cpi_dir=$(cd $(dirname $0)/../ && pwd)
 cpi_gems_dir=${cpi_dir}/src/bosh_${cpi_name}_cpi


### PR DESCRIPTION
Hey, everyone.

Not long ago I needed to update version of bosh_openstack_cpi gems. In order to do it I run `./script/vendor_gems` script. After I did it I've got a following error while trying to run this CPI with bosh-init:
```
Resolving dependencies...
Some gems seem to be missing from your vendor/cache directory.
Your Gemfile has no gem server sources. If you need gems that are not already on
your machine, add a line like this to your Gemfile:
source 'https://rubygems.org'
Could not find gem 'fog-core (>= 0) ruby', which is required by gem
'bosh_openstack_cpi (>= 0) ruby', in any of the sources.
```
After some investigation found a cause of error: I use bundler with version 1.9.1 to generate gems, but this release uses bundler 1.8.2, which has different dependency resolver. 

I've made this PR just to avoid others to have the same tricky error.

Thank you,
Alex L.