### PR TITLE
Fix Keystone v3 support

### DIFF
--- a/src/bosh_openstack_cpi/USAGE.md
+++ b/src/bosh_openstack_cpi/USAGE.md
@@ -12,16 +12,18 @@ These options are passed to the OpenStack CPI when it is instantiated.
 
 The registry options are passed to the Openstack CPI by the BOSH director based on the settings in `director.yml`:
 
-* `auth_url` (required)
+* `auth_url` (required, either API version 2 or version 3)
   URL of the OpenStack Identity endpoint to connect to
 * `username` (required)
   OpenStack user name
 * `api_key` (required)
   OpenStack API key
-* `tenant` (required)
+* `tenant` (required for API version 2)
   OpenStack tenant name
-* `domain` (optional)
+* `domain` (required for API version 3)
   OpenStack domain name
+* `project` (required for API version 3)
+  OpenStack project name
 * `region` (optional)
   OpenStack region
 * `endpoint_type` (optional)

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -56,18 +56,6 @@ module Bosh::OpenStackCloud
 
       @extra_connection_options = {'instrumentor' => Bosh::OpenStackCloud::ExconLoggingInstrumentor}
 
-      openstack_params = {
-          :provider => 'OpenStack',
-          :openstack_auth_url => @openstack_properties['auth_url'],
-          :openstack_username => @openstack_properties['username'],
-          :openstack_api_key => @openstack_properties['api_key'],
-          :openstack_tenant => @openstack_properties['tenant'],
-          :openstack_domain_name => @openstack_properties['domain'],
-          :openstack_region => @openstack_properties['region'],
-          :openstack_endpoint_type => @openstack_properties['endpoint_type'],
-          :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
-      }
-
       connect_retry_errors = [Excon::Errors::GatewayTimeout, Excon::Errors::SocketError]
 
       @connect_retry_options = {
@@ -75,6 +63,20 @@ module Bosh::OpenStackCloud
           tries: CONNECT_RETRY_COUNT,
           on: connect_retry_errors,
       }
+
+      openstack_params = {
+          :provider => 'OpenStack',
+          :openstack_auth_url => @openstack_properties['auth_url'],
+          :openstack_username => @openstack_properties['username'],
+          :openstack_api_key => @openstack_properties['api_key'],
+          :openstack_tenant => @openstack_properties['tenant'],
+          :openstack_project => @openstack_properties['project'],
+          :openstack_domain_name => @openstack_properties['domain'],
+          :openstack_region => @openstack_properties['region'],
+          :openstack_endpoint_type => @openstack_properties['endpoint_type'],
+          :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
+      }
+
 
       begin
         Bosh::Common.retryable(@connect_retry_options) do |tries, error|
@@ -89,25 +91,22 @@ module Bosh::OpenStackCloud
           @openstack,
           @openstack_properties["ignore_server_availability_zone"])
 
-      glance_params = {
-          :provider => 'OpenStack',
-          :openstack_auth_url => @openstack_properties['auth_url'],
-          :openstack_username => @openstack_properties['username'],
-          :openstack_api_key => @openstack_properties['api_key'],
-          :openstack_tenant => @openstack_properties['tenant'],
-          :openstack_domain_name => @openstack_properties['domain'],
-          :openstack_region => @openstack_properties['region'],
-          :openstack_endpoint_type => @openstack_properties['endpoint_type'],
-          :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
-      }
+      begin
+        Bosh::Common.retryable(@connect_retry_options) do |tries, error|
+          @logger.error("Failed #{tries} times, last failure due to: #{error.inspect}") unless error.nil?
+          @glance = Fog::Image.new(openstack_params)
+        end
+      rescue Bosh::Common::RetryCountExceeded, Excon::Errors::ClientError, Excon::Errors::ServerError
+        cloud_error('Unable to connect to the OpenStack Image Service API. Check task debug log for details.')
+      end
 
       begin
         Bosh::Common.retryable(@connect_retry_options) do |tries, error|
           @logger.error("Failed #{tries} times, last failure due to: #{error.inspect}") unless error.nil?
-          @glance = Fog::Image.new(glance_params)
+          @volume ||= Fog::Volume.new(openstack_params)
         end
-      rescue Bosh::Common::RetryCountExceeded, Excon::Errors::ClientError, Excon::Errors::ServerError
-        cloud_error('Unable to connect to the OpenStack Image Service API. Check task debug log for details.')
+      rescue Bosh::Common::RetryCountExceeded, Excon::Errors::ClientError, Excon::Errors::ServerError => e
+        cloud_error("Unable to connect to the OpenStack Volume API: #{e.message}. Check task debug log for details.")
       end
 
       @metadata_lock = Mutex.new
@@ -414,7 +413,6 @@ module Bosh::OpenStackCloud
     #   this disk will be attached to
     # @return [String] OpenStack volume UUID
     def create_disk(size, cloud_properties, server_id = nil)
-      volume_service_client = connect_to_volume_service
       with_thread_name("create_disk(#{size}, #{cloud_properties}, #{server_id})") do
         raise ArgumentError, 'Disk size needs to be an integer' unless size.kind_of?(Integer)
         cloud_error('Minimum disk size is 1 GiB') if (size < 1024)
@@ -437,7 +435,7 @@ module Bosh::OpenStackCloud
         end
 
         @logger.info('Creating new volume...')
-        new_volume = with_openstack { volume_service_client.volumes.create(volume_params) }
+        new_volume = with_openstack { @volume.volumes.create(volume_params) }
 
         @logger.info("Creating new volume `#{new_volume.id}'...")
         wait_resource(new_volume, :available)
@@ -663,36 +661,6 @@ module Bosh::OpenStackCloud
     end
 
     private
-
-    ##
-    # Creates a client for the OpenStack volume service, or return
-    # the existing connectuion
-    #
-    #
-    def connect_to_volume_service
-      volume_params = {
-          :provider => "OpenStack",
-          :openstack_auth_url => @openstack_properties['auth_url'],
-          :openstack_username => @openstack_properties['username'],
-          :openstack_api_key => @openstack_properties['api_key'],
-          :openstack_tenant => @openstack_properties['tenant'],
-          :openstack_domain_name => @openstack_properties['domain'],
-          :openstack_region => @openstack_properties['region'],
-          :openstack_endpoint_type => @openstack_properties['endpoint_type'],
-          :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
-      }
-
-      begin
-        Bosh::Common.retryable(@connect_retry_options) do |tries, error|
-          @logger.error("Failed #{tries} times, last failure due to: #{error.inspect}") unless error.nil?
-          @volume ||= Fog::Volume.new(volume_params)
-        end
-      rescue Bosh::Common::RetryCountExceeded, Excon::Errors::ClientError, Excon::Errors::ServerError => e
-        cloud_error("Unable to connect to the OpenStack Volume API: #{e.message}. Check task debug log for details.")
-      end
-
-      @volume
-    end
 
     ##
     # Generates an unique name
@@ -973,32 +941,62 @@ module Bosh::OpenStackCloud
     # @return [void]
     # @raise [ArgumentError] if options are not valid
     def validate_options
-      schema = Membrane::SchemaParser.parse do
-        {
-            'openstack' => {
-                'auth_url' => String,
-                'username' => String,
-                'api_key' => String,
-                'tenant' => String,
-                optional('domain') => String,
-                optional('region') => String,
-                optional('endpoint_type') => String,
-                optional('state_timeout') => Numeric,
-                optional('stemcell_public_visibility') => enum(String, bool),
-                optional('connection_options') => Hash,
-                optional('boot_from_volume') => bool,
-                optional('default_key_name') => String,
-                optional('default_security_groups') => [String],
-                optional('wait_resource_poll_interval') => Integer,
-                optional('config_drive') => enum('disk', 'cdrom'),
-            },
-            'registry' => {
-                'endpoint' => String,
-                'user' => String,
-                'password' => String,
-            },
-            optional('agent') => Hash,
-        }
+      if @options['openstack'] && @options['openstack']['auth_url'].match(/\/v3[\.\d]/)
+        schema = Membrane::SchemaParser.parse do
+          {
+              'openstack' => {
+                  'auth_url' => String,
+                  'username' => String,
+                  'api_key' => String,
+                  'project' => String,
+                  'domain' => String,
+                  optional('region') => String,
+                  optional('endpoint_type') => String,
+                  optional('state_timeout') => Numeric,
+                  optional('stemcell_public_visibility') => enum(String, bool),
+                  optional('connection_options') => Hash,
+                  optional('boot_from_volume') => bool,
+                  optional('default_key_name') => String,
+                  optional('default_security_groups') => [String],
+                  optional('wait_resource_poll_interval') => Integer,
+                  optional('config_drive') => enum('disk', 'cdrom'),
+              },
+              'registry' => {
+                  'endpoint' => String,
+                  'user' => String,
+                  'password' => String,
+              },
+              optional('agent') => Hash,
+          }
+        end
+      else
+        schema = Membrane::SchemaParser.parse do
+          {
+              'openstack' => {
+                  'auth_url' => String,
+                  'username' => String,
+                  'api_key' => String,
+                  'tenant' => String,
+                  optional('domain') => String,
+                  optional('region') => String,
+                  optional('endpoint_type') => String,
+                  optional('state_timeout') => Numeric,
+                  optional('stemcell_public_visibility') => enum(String, bool),
+                  optional('connection_options') => Hash,
+                  optional('boot_from_volume') => bool,
+                  optional('default_key_name') => String,
+                  optional('default_security_groups') => [String],
+                  optional('wait_resource_poll_interval') => Integer,
+                  optional('config_drive') => enum('disk', 'cdrom'),
+              },
+              'registry' => {
+                  'endpoint' => String,
+                  'user' => String,
+                  'password' => String,
+              },
+              optional('agent') => Hash,
+          }
+        end
       end
       schema.validate(@options)
     rescue Membrane::SchemaValidationError => e

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -70,7 +70,7 @@ module Bosh::OpenStackCloud
           :openstack_username => @openstack_properties['username'],
           :openstack_api_key => @openstack_properties['api_key'],
           :openstack_tenant => @openstack_properties['tenant'],
-          :openstack_project => @openstack_properties['project'],
+          :openstack_project_name => @openstack_properties['project'],
           :openstack_domain_name => @openstack_properties['domain'],
           :openstack_region => @openstack_properties['region'],
           :openstack_endpoint_type => @openstack_properties['endpoint_type'],

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -57,23 +57,23 @@ module Bosh::OpenStackCloud
       @extra_connection_options = {'instrumentor' => Bosh::OpenStackCloud::ExconLoggingInstrumentor}
 
       openstack_params = {
-        :provider => 'OpenStack',
-        :openstack_auth_url => @openstack_properties['auth_url'],
-        :openstack_username => @openstack_properties['username'],
-        :openstack_api_key => @openstack_properties['api_key'],
-        :openstack_tenant => @openstack_properties['tenant'],
-        :openstack_domain_name => @openstack_properties['domain'],
-        :openstack_region => @openstack_properties['region'],
-        :openstack_endpoint_type => @openstack_properties['endpoint_type'],
-        :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
+          :provider => 'OpenStack',
+          :openstack_auth_url => @openstack_properties['auth_url'],
+          :openstack_username => @openstack_properties['username'],
+          :openstack_api_key => @openstack_properties['api_key'],
+          :openstack_tenant => @openstack_properties['tenant'],
+          :openstack_domain_name => @openstack_properties['domain'],
+          :openstack_region => @openstack_properties['region'],
+          :openstack_endpoint_type => @openstack_properties['endpoint_type'],
+          :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
       }
 
       connect_retry_errors = [Excon::Errors::GatewayTimeout, Excon::Errors::SocketError]
 
       @connect_retry_options = {
-        sleep: CONNECT_RETRY_DELAY,
-        tries: CONNECT_RETRY_COUNT,
-        on: connect_retry_errors,
+          sleep: CONNECT_RETRY_DELAY,
+          tries: CONNECT_RETRY_COUNT,
+          on: connect_retry_errors,
       }
 
       begin
@@ -86,19 +86,19 @@ module Bosh::OpenStackCloud
       end
 
       @az_provider = Bosh::OpenStackCloud::AvailabilityZoneProvider.new(
-        @openstack,
-        @openstack_properties["ignore_server_availability_zone"])
+          @openstack,
+          @openstack_properties["ignore_server_availability_zone"])
 
       glance_params = {
-        :provider => 'OpenStack',
-        :openstack_auth_url => @openstack_properties['auth_url'],
-        :openstack_username => @openstack_properties['username'],
-        :openstack_api_key => @openstack_properties['api_key'],
-        :openstack_tenant => @openstack_properties['tenant'],
-        :openstack_domain_name => @openstack_properties['domain'],
-        :openstack_region => @openstack_properties['region'],
-        :openstack_endpoint_type => @openstack_properties['endpoint_type'],
-        :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
+          :provider => 'OpenStack',
+          :openstack_auth_url => @openstack_properties['auth_url'],
+          :openstack_username => @openstack_properties['username'],
+          :openstack_api_key => @openstack_properties['api_key'],
+          :openstack_tenant => @openstack_properties['tenant'],
+          :openstack_domain_name => @openstack_properties['domain'],
+          :openstack_region => @openstack_properties['region'],
+          :openstack_endpoint_type => @openstack_properties['endpoint_type'],
+          :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
       }
 
       begin
@@ -135,17 +135,17 @@ module Bosh::OpenStackCloud
           Dir.mktmpdir do |tmp_dir|
             @logger.info('Creating new image...')
             image_params = {
-              :name => "BOSH-#{generate_unique_name}",
-              :disk_format => cloud_properties['disk_format'],
-              :container_format => cloud_properties['container_format'],
-              :is_public => @stemcell_public_visibility.nil? ? false : @stemcell_public_visibility,
+                :name => "BOSH-#{generate_unique_name}",
+                :disk_format => cloud_properties['disk_format'],
+                :container_format => cloud_properties['container_format'],
+                :is_public => @stemcell_public_visibility.nil? ? false : @stemcell_public_visibility,
             }
 
             image_properties = {}
             vanilla_options = ['name', 'version', 'os_type', 'os_distro', 'architecture', 'auto_disk_config',
                                'hw_vif_model', 'hypervisor_type', 'vmware_adaptertype', 'vmware_disktype',
                                'vmware_linked_clone', 'vmware_ostype']
-            vanilla_options.reject{ |o| cloud_properties[o].nil? }.each do |key|
+            vanilla_options.reject { |o| cloud_properties[o].nil? }.each do |key|
               image_properties[key.to_sym] = cloud_properties[key]
             end
             image_params[:properties] = image_properties unless image_properties.empty?
@@ -254,7 +254,7 @@ module Bosh::OpenStackCloud
             min_ephemeral_size = (flavor.ram / 1024) * 2
             if flavor.ephemeral < min_ephemeral_size
               cloud_error("Flavor `#{resource_pool['instance_type']}' should have at least #{min_ephemeral_size}Gb " +
-                'of ephemeral disk')
+                              'of ephemeral disk')
             end
           end
         end
@@ -272,15 +272,15 @@ module Bosh::OpenStackCloud
         end
 
         server_params = {
-          :name => server_name,
-          :image_ref => image.id,
-          :flavor_ref => flavor.id,
-          :key_name => keypair.name,
-          :security_groups => security_groups,
-          :os_scheduler_hints => resource_pool['scheduler_hints'],
-          :nics => nics,
-          :config_drive => use_config_drive,
-          :user_data => Yajl::Encoder.encode(user_data(server_name, network_spec))
+            :name => server_name,
+            :image_ref => image.id,
+            :flavor_ref => flavor.id,
+            :key_name => keypair.name,
+            :security_groups => security_groups,
+            :os_scheduler_hints => resource_pool['scheduler_hints'],
+            :nics => nics,
+            :config_drive => use_config_drive,
+            :user_data => Yajl::Encoder.encode(user_data(server_name, network_spec))
         }
 
         availability_zone = @az_provider.select(disk_locality, resource_pool['availability_zone'])
@@ -294,11 +294,11 @@ module Bosh::OpenStackCloud
           @logger.debug("Using boot volume: `#{boot_vol_id}'")
 
           server_params[:block_device_mapping] = [{
-                                                   :volume_size => boot_vol_size,
-                                                   :volume_id => boot_vol_id,
-                                                   :delete_on_termination => "1",
-                                                   :device_name => "/dev/vda"
-                                                 }]
+                                                      :volume_size => boot_vol_size,
+                                                      :volume_id => boot_vol_id,
+                                                      :delete_on_termination => "1",
+                                                      :device_name => "/dev/vda"
+                                                  }]
         end
 
         @logger.debug("Using boot parms: `#{server_params.inspect}'")
@@ -420,16 +420,16 @@ module Bosh::OpenStackCloud
         cloud_error('Minimum disk size is 1 GiB') if (size < 1024)
 
         volume_params = {
-          :display_name => "volume-#{generate_unique_name}",
-          :display_description => '',
-          :size => (size / 1024.0).ceil
+            :display_name => "volume-#{generate_unique_name}",
+            :display_description => '',
+            :size => (size / 1024.0).ceil
         }
 
         if cloud_properties.has_key?('type')
           volume_params[:volume_type] = cloud_properties['type']
         end
 
-        if server_id  && @az_provider.constrain_to_server_availability_zone?
+        if server_id && @az_provider.constrain_to_server_availability_zone?
           server = with_openstack { @openstack.servers.get(server_id) }
           if server && server.availability_zone
             volume_params[:availability_zone] = server.availability_zone
@@ -462,9 +462,9 @@ module Bosh::OpenStackCloud
         cloud_error("Minimum disk size is 1 GiB") if (size < 1024)
 
         volume_params = {
-          :display_name => "volume-#{generate_unique_name}",
-          :size => (size / 1024.0).ceil,
-          :imageRef => stemcell_id
+            :display_name => "volume-#{generate_unique_name}",
+            :size => (size / 1024.0).ceil,
+            :imageRef => stemcell_id
         }
 
         if availability_zone && @az_provider.constrain_to_server_availability_zone?
@@ -579,7 +579,7 @@ module Bosh::OpenStackCloud
     # @raise [Bosh::Clouds::CloudError] if volume is not found
     def snapshot_disk(disk_id, metadata)
       with_thread_name("snapshot_disk(#{disk_id})") do
-        metadata = Hash[metadata.map{|key,value| [key.to_s, value] }]
+        metadata = Hash[metadata.map { |key, value| [key.to_s, value] }]
         volume = with_openstack { @openstack.volumes.get(disk_id) }
         cloud_error("Volume `#{disk_id}' not found") unless volume
 
@@ -589,9 +589,9 @@ module Bosh::OpenStackCloud
         description = ['deployment', 'job', 'index'].collect { |key| metadata[key] }
         description << devices.first.split('/').last unless devices.empty?
         snapshot_params = {
-          :name => "snapshot-#{generate_unique_name}",
-          :description => description.join('/'),
-          :volume_id => volume.id
+            :name => "snapshot-#{generate_unique_name}",
+            :description => description.join('/'),
+            :volume_id => volume.id
         }
 
         @logger.info("Creating new snapshot for volume `#{disk_id}'...")
@@ -671,15 +671,15 @@ module Bosh::OpenStackCloud
     #
     def connect_to_volume_service
       volume_params = {
-        :provider => "OpenStack",
-        :openstack_auth_url => @openstack_properties['auth_url'],
-        :openstack_username => @openstack_properties['username'],
-        :openstack_api_key => @openstack_properties['api_key'],
-        :openstack_tenant => @openstack_properties['tenant'],
-        :openstack_domain_name => @openstack_properties['domain'],
-        :openstack_region => @openstack_properties['region'],
-        :openstack_endpoint_type => @openstack_properties['endpoint_type'],
-        :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
+          :provider => "OpenStack",
+          :openstack_auth_url => @openstack_properties['auth_url'],
+          :openstack_username => @openstack_properties['username'],
+          :openstack_api_key => @openstack_properties['api_key'],
+          :openstack_tenant => @openstack_properties['tenant'],
+          :openstack_domain_name => @openstack_properties['domain'],
+          :openstack_region => @openstack_properties['region'],
+          :openstack_endpoint_type => @openstack_properties['endpoint_type'],
+          :connection_options => @openstack_properties['connection_options'].merge(@extra_connection_options)
       }
 
       begin
@@ -711,13 +711,13 @@ module Bosh::OpenStackCloud
     def user_data(server_name, network_spec, public_key = nil)
       data = {}
 
-      data['registry'] = { 'endpoint' => @registry.endpoint }
-      data['server'] = { 'name' => server_name }
-      data['openssh'] = { 'public_key' => public_key } if public_key
+      data['registry'] = {'endpoint' => @registry.endpoint}
+      data['server'] = {'name' => server_name}
+      data['openssh'] = {'public_key' => public_key} if public_key
       data['networks'] = agent_network_spec(network_spec)
 
       with_dns(network_spec) do |servers|
-        data['dns'] = { 'nameserver' => servers }
+        data['dns'] = {'nameserver' => servers}
       end
 
       data
@@ -755,15 +755,15 @@ module Bosh::OpenStackCloud
     # @return [Hash] Agent settings
     def initial_agent_settings(server_name, agent_id, network_spec, environment, has_ephemeral)
       settings = {
-        'vm' => {
-          'name' => server_name
-        },
-        'agent_id' => agent_id,
-        'networks' => agent_network_spec(network_spec),
-        'disks' => {
-          'system' => '/dev/sda',
-          'persistent' => {}
-        }
+          'vm' => {
+              'name' => server_name
+          },
+          'agent_id' => agent_id,
+          'networks' => agent_network_spec(network_spec),
+          'disks' => {
+              'system' => '/dev/sda',
+              'persistent' => {}
+          }
       }
 
       settings['disks']['ephemeral'] = has_ephemeral ? '/dev/sdb' : nil
@@ -773,9 +773,9 @@ module Bosh::OpenStackCloud
 
     def agent_network_spec(network_spec)
       Hash[*network_spec.map do |name, settings|
-        settings['use_dhcp'] = @use_dhcp
-        [name, settings]
-      end.flatten]
+             settings['use_dhcp'] = @use_dhcp
+             [name, settings]
+           end.flatten]
     end
 
     ##
@@ -850,7 +850,7 @@ module Bosh::OpenStackCloud
         # Some kernels remap device names (from sd* to vd* or xvd*).
         device_names = ["/dev/sd#{char}", "/dev/vd#{char}", "/dev/xvd#{char}"]
         # Bosh Agent will lookup for the proper device name if we set it initially to sd*.
-        return "/dev/sd#{char}" if volume_attachments.select { |v| device_names.include?( v['device']) }.empty?
+        return "/dev/sd#{char}" if volume_attachments.select { |v| device_names.include?(v['device']) }.empty?
         @logger.warn("`/dev/sd#{char}' is already taken")
       end
 
@@ -907,7 +907,7 @@ module Bosh::OpenStackCloud
       unless actual_sg_names.sort == specified_sg_names.sort
         raise Bosh::Clouds::NotSupported,
               'security groups change requires VM recreation: %s to %s' %
-              [actual_sg_names.join(', '), specified_sg_names.join(', ')]
+                  [actual_sg_names.join(', '), specified_sg_names.join(', ')]
       end
     end
 
@@ -925,7 +925,7 @@ module Bosh::OpenStackCloud
       unless specified_ip_addresses.empty? || actual_ip_addresses.sort == specified_ip_addresses.sort
         raise Bosh::Clouds::NotSupported,
               'IP address change requires VM recreation: %s to %s' %
-              [actual_ip_addresses.join(', '), specified_ip_addresses.join(', ')]
+                  [actual_ip_addresses.join(', '), specified_ip_addresses.join(', ')]
       end
     end
 
@@ -957,7 +957,7 @@ module Bosh::OpenStackCloud
       result = Bosh::Exec.sh("tar -C #{tmp_dir} -xzf #{image_path} 2>&1", :on_error => :return)
       if result.failed?
         @logger.error("Extracting stemcell root image failed in dir #{tmp_dir}, " +
-                      "tar returned #{result.exit_status}, output: #{result.output}")
+                          "tar returned #{result.exit_status}, output: #{result.output}")
         cloud_error('Extracting stemcell root image failed. Check task debug log for details.')
       end
       root_image = File.join(tmp_dir, 'root.img')
@@ -975,29 +975,29 @@ module Bosh::OpenStackCloud
     def validate_options
       schema = Membrane::SchemaParser.parse do
         {
-          'openstack' => {
-            'auth_url' => String,
-            'username' => String,
-            'api_key' => String,
-            'tenant' => String,
-            optional('domain') => String,
-            optional('region') => String,
-            optional('endpoint_type') => String,
-            optional('state_timeout') => Numeric,
-            optional('stemcell_public_visibility') => enum(String, bool),
-            optional('connection_options') => Hash,
-            optional('boot_from_volume') => bool,
-            optional('default_key_name') => String,
-            optional('default_security_groups') => [String],
-            optional('wait_resource_poll_interval') => Integer,
-            optional('config_drive') => enum('disk', 'cdrom'),
-          },
-          'registry' => {
-            'endpoint' => String,
-            'user' => String,
-            'password' => String,
-          },
-          optional('agent') => Hash,
+            'openstack' => {
+                'auth_url' => String,
+                'username' => String,
+                'api_key' => String,
+                'tenant' => String,
+                optional('domain') => String,
+                optional('region') => String,
+                optional('endpoint_type') => String,
+                optional('state_timeout') => Numeric,
+                optional('stemcell_public_visibility') => enum(String, bool),
+                optional('connection_options') => Hash,
+                optional('boot_from_volume') => bool,
+                optional('default_key_name') => String,
+                optional('default_security_groups') => [String],
+                optional('wait_resource_poll_interval') => Integer,
+                optional('config_drive') => enum('disk', 'cdrom'),
+            },
+            'registry' => {
+                'endpoint' => String,
+                'user' => String,
+                'password' => String,
+            },
+            optional('agent') => Hash,
         }
       end
       schema.validate(@options)
@@ -1007,9 +1007,9 @@ module Bosh::OpenStackCloud
 
     def initialize_registry
       registry_properties = @options.fetch('registry')
-      registry_endpoint   = registry_properties.fetch('endpoint')
-      registry_user       = registry_properties.fetch('user')
-      registry_password   = registry_properties.fetch('password')
+      registry_endpoint = registry_properties.fetch('endpoint')
+      registry_user = registry_properties.fetch('user')
+      registry_password = registry_properties.fetch('password')
 
       @registry = Bosh::Registry::Client.new(registry_endpoint,
                                              registry_user,

--- a/src/bosh_openstack_cpi/spec/spec_helper.rb
+++ b/src/bosh_openstack_cpi/spec/spec_helper.rb
@@ -5,30 +5,57 @@ include Archive::Tar
 
 require 'cloud/openstack'
 
-def mock_cloud_options
-  {
-    'plugin' => 'openstack',
-    'properties' => {
-      'openstack' => {
-        'auth_url' => 'http://127.0.0.1:5000/v2.0',
-        'username' => 'admin',
-        'api_key' => 'nova',
-        'tenant' => 'admin',
-        'region' => 'RegionOne',
-        'state_timeout' => 1,
-        'wait_resource_poll_interval' => 3
-      },
-      'registry' => {
-        'endpoint' => 'localhost:42288',
-        'user' => 'admin',
-        'password' => 'admin'
-      },
-      'agent' => {
-        'foo' => 'bar',
-        'baz' => 'zaz'
-      }
+def mock_cloud_options(api_version=2)
+  if api_version == 2
+    {
+        'plugin' => 'openstack',
+        'properties' => {
+            'openstack' => {
+                'auth_url' => 'http://127.0.0.1:5000/v2.0',
+                'username' => 'admin',
+                'api_key' => 'nova',
+                'tenant' => 'admin',
+                'region' => 'RegionOne',
+                'state_timeout' => 1,
+                'wait_resource_poll_interval' => 3
+            },
+            'registry' => {
+                'endpoint' => 'localhost:42288',
+                'user' => 'admin',
+                'password' => 'admin'
+            },
+            'agent' => {
+                'foo' => 'bar',
+                'baz' => 'zaz'
+            }
+        }
     }
-  }
+  elsif api_version == 3
+    {
+        'plugin' => 'openstack',
+        'properties' => {
+            'openstack' => {
+                'auth_url' => 'http://127.0.0.1:5000/v3.0',
+                'username' => 'admin',
+                'api_key' => 'nova',
+                'project' => 'admin',
+                'domain' => 'some_domain',
+                'region' => 'RegionOne',
+                'state_timeout' => 1,
+                'wait_resource_poll_interval' => 3
+            },
+            'registry' => {
+                'endpoint' => 'localhost:42288',
+                'user' => 'admin',
+                'password' => 'admin'
+            },
+            'agent' => {
+                'foo' => 'bar',
+                'baz' => 'zaz'
+            }
+        }
+    }
+  end
 end
 
 def make_cloud(options = nil)
@@ -97,67 +124,67 @@ end
 
 def dynamic_network_spec
   {
-    'type' => 'dynamic',
-    'cloud_properties' => {
-      'security_groups' => %w[default]
-    },
-    'use_dhcp' => true
+      'type' => 'dynamic',
+      'cloud_properties' => {
+          'security_groups' => %w[default]
+      },
+      'use_dhcp' => true
   }
 end
 
 def manual_network_spec
   {
-    'type' => 'manual',
-    'cloud_properties' => {
-      'security_groups' => %w[default],
-      'net_id' => 'net'
-    },
-    'use_dhcp' => true
+      'type' => 'manual',
+      'cloud_properties' => {
+          'security_groups' => %w[default],
+          'net_id' => 'net'
+      },
+      'use_dhcp' => true
   }
 end
 
 def manual_network_without_netid_spec
   {
-    'type' => 'manual',
-    'cloud_properties' => {
-      'security_groups' => %w[default],
-    }
+      'type' => 'manual',
+      'cloud_properties' => {
+          'security_groups' => %w[default],
+      }
   }
 end
 
 def dynamic_network_with_netid_spec
   {
-    'type' => 'dynamic',
-    'cloud_properties' => {
-      'security_groups' => %w[default],
-      'net_id' => 'net'
-    }
+      'type' => 'dynamic',
+      'cloud_properties' => {
+          'security_groups' => %w[default],
+          'net_id' => 'net'
+      }
   }
 end
 
 def vip_network_spec
   {
-    'type' => 'vip',
-    'ip' => '10.0.0.1',
-    'use_dhcp' => true
+      'type' => 'vip',
+      'ip' => '10.0.0.1',
+      'use_dhcp' => true
   }
 end
 
 def combined_network_spec
   {
-    'network_a' => dynamic_network_spec,
-    'network_b' => vip_network_spec
+      'network_a' => dynamic_network_spec,
+      'network_b' => vip_network_spec
   }
 end
 
 def resource_pool_spec
   {
-    'key_name' => 'test_key',
-    'availability_zone' => 'foobar-1a',
-    'instance_type' => 'm1.tiny'
+      'key_name' => 'test_key',
+      'availability_zone' => 'foobar-1a',
+      'instance_type' => 'm1.tiny'
   }
 end
 
 RSpec.configure do |config|
-  config.before(:each) { allow(Bosh::Clouds::Config).to receive(:logger).and_return(double.as_null_object)  }
+  config.before(:each) { allow(Bosh::Clouds::Config).to receive(:logger).and_return(double.as_null_object) }
 end

--- a/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Bosh::OpenStackCloud::Cloud do
   let(:default_connection_options) {
-    { "instrumentor" => Bosh::OpenStackCloud::ExconLoggingInstrumentor }
+    {"instrumentor" => Bosh::OpenStackCloud::ExconLoggingInstrumentor}
   }
 
   describe :new do
@@ -20,17 +20,17 @@ describe Bosh::OpenStackCloud::Cloud do
     describe 'validation' do
       let(:options) do
         {
-          'openstack' => {
-            'auth_url' => 'fake-auth-url',
-            'username' => 'fake-username',
-            'api_key' => 'fake-api-key',
-            'tenant' => 'fake-tenant'
-          },
-          'registry' => {
-            'endpoint' => 'fake-registry',
-            'user' => 'fake-user',
-            'password' => 'fake-password',
-          }
+            'openstack' => {
+                'auth_url' => 'fake-auth-url',
+                'username' => 'fake-username',
+                'api_key' => 'fake-api-key',
+                'tenant' => 'fake-tenant'
+            },
+            'registry' => {
+                'endpoint' => 'fake-registry',
+                'user' => 'fake-user',
+                'password' => 'fake-password',
+            }
         }
       end
       subject(:subject) { Bosh::OpenStackCloud::Cloud.new(options) }
@@ -43,7 +43,7 @@ describe Bosh::OpenStackCloud::Cloud do
 
       context 'when connection_options are specified' do
         it 'expects connection_options to be a hash' do
-          options['openstack']['connection_options'] = { 'any-key' => 'any-value' }
+          options['openstack']['connection_options'] = {'any-key' => 'any-value'}
 
           expect { subject }.to_not raise_error
         end
@@ -169,7 +169,7 @@ describe Bosh::OpenStackCloud::Cloud do
       expect {
         Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
       }.to raise_error(Bosh::Clouds::CloudError,
-        'Unable to connect to the OpenStack Compute API. Check task debug log for details.')
+                       'Unable to connect to the OpenStack Compute API. Check task debug log for details.')
     end
 
     it 'raises a CloudError exception if cannot connect to the OpenStack Image Service API 5 times' do
@@ -179,7 +179,7 @@ describe Bosh::OpenStackCloud::Cloud do
       expect {
         Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
       }.to raise_error(Bosh::Clouds::CloudError,
-        'Unable to connect to the OpenStack Image Service API. Check task debug log for details.')
+                       'Unable to connect to the OpenStack Image Service API. Check task debug log for details.')
     end
 
     context 'with connection options' do

--- a/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
@@ -7,18 +7,7 @@ describe Bosh::OpenStackCloud::Cloud do
 
   describe :new do
     let(:cloud_options) { mock_cloud_options }
-    let(:openstack_parms) {
-      {
-        :provider => 'OpenStack',
-        :openstack_auth_url => 'http://127.0.0.1:5000/v2.0/tokens',
-        :openstack_username => 'admin',
-        :openstack_api_key => 'nova',
-        :openstack_tenant => 'admin',
-        :openstack_region => 'RegionOne',
-        :openstack_endpoint_type => nil,
-        :connection_options => merged_connection_options,
-      }
-    }
+
     let(:connection_options) { nil }
     let(:merged_connection_options) { default_connection_options }
 
@@ -120,7 +109,7 @@ describe Bosh::OpenStackCloud::Cloud do
     end
 
     it 'creates a Fog connection' do
-      cloud = Bosh::OpenStackCloud::Cloud.new(mock_cloud_options['properties'])
+      cloud = Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
 
       expect(cloud.openstack).to eql(compute)
       expect(cloud.glance).to eql(image)
@@ -139,7 +128,7 @@ describe Bosh::OpenStackCloud::Cloud do
       allow(Fog::Image).to receive(:new).and_return(instance_double(Fog::Image))
       allow(Fog::Volume).to receive(:new).and_return(instance_double(Fog::Volume))
       expect {
-        Bosh::OpenStackCloud::Cloud.new(mock_cloud_options['properties'])
+        Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
       }.to_not raise_error
 
       retry_count = 0
@@ -154,7 +143,7 @@ describe Bosh::OpenStackCloud::Cloud do
       allow(Fog::Compute).to receive(:new).and_return(instance_double(Fog::Compute))
       allow(Fog::Volume).to receive(:new).and_return(instance_double(Fog::Volume))
       expect {
-        Bosh::OpenStackCloud::Cloud.new(mock_cloud_options['properties'])
+        Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
       }.to_not raise_error
 
       retry_count = 0
@@ -169,7 +158,7 @@ describe Bosh::OpenStackCloud::Cloud do
       allow(Fog::Compute).to receive(:new).and_return(instance_double(Fog::Compute))
       allow(Fog::Image).to receive(:new).and_return(instance_double(Fog::Image))
       expect {
-        Bosh::OpenStackCloud::Cloud.new(mock_cloud_options['properties'])
+        Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
       }.to_not raise_error
     end
 
@@ -178,7 +167,7 @@ describe Bosh::OpenStackCloud::Cloud do
       allow(Fog::Image).to receive(:new).and_return(instance_double(Fog::Image))
       allow(Fog::Volume).to receive(:new).and_return(instance_double(Fog::Volume))
       expect {
-        Bosh::OpenStackCloud::Cloud.new(mock_cloud_options['properties'])
+        Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
       }.to raise_error(Bosh::Clouds::CloudError,
         'Unable to connect to the OpenStack Compute API. Check task debug log for details.')
     end
@@ -188,7 +177,7 @@ describe Bosh::OpenStackCloud::Cloud do
       allow(Fog::Image).to receive(:new).and_raise(Excon::Errors::Unauthorized, 'Unauthorized')
       allow(Fog::Volume).to receive(:new).and_return(instance_double(Fog::Volume))
       expect {
-        Bosh::OpenStackCloud::Cloud.new(mock_cloud_options['properties'])
+        Bosh::OpenStackCloud::Cloud.new(cloud_options['properties'])
       }.to raise_error(Bosh::Clouds::CloudError,
         'Unable to connect to the OpenStack Image Service API. Check task debug log for details.')
     end


### PR DESCRIPTION
Bug: https://github.com/cloudfoundry/bosh/issues/939

* When using the Keystone V3 API, the `openstack_tenant` parameter is renamed to `openstack_project_name` in fog
* Have different validation strategies for the corresponding API versions: V2 requires a different set of properties than V3

required for V3 to work:
* Change bosh director to accept the `project` parameter
* Update bosh to use fog >=1.34.0 to include fixes necessary for V3 API support
* Adapt `bosh_openstack_cpi.gemspec` to remove lock-down of `fog-aws`, update to fog >= 1.34.0 and `vendor_gems` in here so the new gems get pulled in