### PR TITLE
Bump gem version and update fog to 1.34.0

### DIFF
--- a/src/bosh_openstack_cpi/bosh_openstack_cpi.gemspec
+++ b/src/bosh_openstack_cpi/bosh_openstack_cpi.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |s|
   s.name        = 'bosh_openstack_cpi'
-  s.version     = '2.0.0'
+  s.version     = '2.1.0'
   s.platform    = Gem::Platform::RUBY
   s.summary     = 'BOSH OpenStack CPI'
   s.description = 'BOSH OpenStack CPI'
@@ -22,8 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'bosh_common'
   s.add_dependency 'bosh_cpi'
   s.add_dependency 'bosh-registry'
-  s.add_dependency 'fog-aws',       '<=0.1.1'
-  s.add_dependency 'fog',           '~>1.31.0'
+  s.add_dependency 'fog',           '~>1.34.0'
   s.add_dependency 'httpclient',    '=2.4.0'
   s.add_dependency 'yajl-ruby',     '>=0.8.2'
   s.add_dependency 'membrane',      '~>1.1.0'


### PR DESCRIPTION
Bug: https://github.com/cloudfoundry/bosh/issues/939

Removes lock-down of fog-aws to update fog. 