### PR TITLE
Read the JSON line from the standard input in raw mode

### DIFF
--- a/jobs/openstack_cpi/templates/cpi.erb
+++ b/jobs/openstack_cpi/templates/cpi.erb
@@ -15,7 +15,7 @@ export NO_PROXY=<%= no_proxy %>
 export no_proxy=<%= no_proxy %>
 <% end %>
 
-read INPUT
+read -r INPUT
 
 BOSH_PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 BOSH_JOBS_DIR=${BOSH_JOBS_DIR:-/var/vcap/jobs}


### PR DESCRIPTION
Hi,

without the `-r` option of the [`read`](http://linuxcommand.org/lc3_man_pages/readh.html) command, backslashes in JSON strings are interpreted as bash escape character. The following simple example illustrates the problem:

**without  the `-r` option**
```bash
$ echo '{"arguments":["\"\ud83d\udc4d\""]}' | (read INPUT; echo $INPUT) | jq -r .arguments[0]
parse error: Invalid numeric literal at line 1, column 27
```
**with the  `-r` option**
```bash
$ echo '{"arguments":["\"\ud83d\udc4d\""]}' | (read -r INPUT; echo $INPUT) | jq -r .arguments[0]
"👍"
```

In order to make sure that valid JSON is forwarded to the `openstack_cpi` ruby script, do not allow backslashes to escape any characters in the `cpi` shell script by using the `-r` option of the `read` command.

This seems to be a problem also in other cpi bosh releases e.g [bosh-aws-cpi-release](https://github.com/cloudfoundry-incubator/bosh-aws-cpi-release/blob/master/jobs/aws_cpi/templates/cpi.erb#L18).

Best regards, Holger