### PR TITLE
Allow operator to specify s3 signature version and region in manifest

### DIFF
--- a/jobs/openstack_cpi/spec
+++ b/jobs/openstack_cpi/spec
@@ -94,6 +94,8 @@ properties:
     description: Address for agent to connect to blobstore server used by simple blobstore plugin
   agent.blobstore.use_ssl:
     description: Whether the agent blobstore plugin should use SSL to connect to the blobstore server
+  agent.blobstore.s3_region:
+    description: AWS region for agent used by s3 blobstore plugin
   agent.blobstore.s3_port:
     description: Port of agent blobstore server used by s3 blobstore plugin
   agent.blobstore.host:
@@ -104,6 +106,8 @@ properties:
     description: Whether the agent blobstore plugin should verify its peer when using SSL
   agent.blobstore.s3_multipart_threshold:
     description: Agent blobstore threshold for multipart uploads
+  agent.blobstore.s3_signature_version:
+    description: Signature version used to connect to an s3 blobstore
 
   blobstore.address:
     description: Address for agent to connect to blobstore server used by 'simple' blobstore plugin
@@ -125,6 +129,9 @@ properties:
     description: secret_access_key used by s3 blobstore plugin
   blobstore.host:
     description: Host of blobstore server used by simple blobstore plugin
+  blobstore.s3_region:
+    description: AWS region used by s3 blobstore plugin
+    default: 'us-east-1'
   blobstore.s3_port:
     description: Port of blobstore server used by s3 blobstore plugin
     default: 443
@@ -139,6 +146,8 @@ properties:
     default: false
   blobstore.s3_multipart_threshold:
     description: Simple blobstore threshold for multipart uploads
+  blobstore.s3_signature_version:
+    description: Signature version used to connect to an s3 blobstore
 
   nats.user:
     description: NATS username used by agent to subscribe to agent requests

--- a/jobs/openstack_cpi/templates/cpi.json.erb
+++ b/jobs/openstack_cpi/templates/cpi.json.erb
@@ -56,7 +56,8 @@
       options_params = {
         'bucket_name' => p('blobstore.bucket_name'),
         'access_key_id' => p(['agent.blobstore.access_key_id', 'blobstore.access_key_id']),
-        'secret_access_key' => p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key'])
+        'secret_access_key' => p(['agent.blobstore.secret_access_key', 'blobstore.secret_access_key']),
+        'region' => p(['agent.blobstore.s3_region', 'blobstore.s3_region']),
       }
 
       def update_blobstore_options(options, manifest_key, rendered_key=manifest_key)
@@ -70,6 +71,7 @@
       update_blobstore_options(options_params, 's3_force_path_style')
       update_blobstore_options(options_params, 'ssl_verify_peer')
       update_blobstore_options(options_params, 's3_multipart_threshold')
+      update_blobstore_options(options_params, 's3_signature_version', 'signature_version')
 
 
     elsif p('blobstore.provider') == 'local'
@@ -93,6 +95,6 @@
   end.else_if_p('nats') do
     params['cloud']['properties']['agent']['mbus'] = "nats://#{p('nats.user')}:#{p('nats.password')}@#{p(['agent.nats.address', 'nats.address'])}:#{p('nats.port')}"
   end
-  
+
   JSON.dump(params)
 %>


### PR DESCRIPTION
- Can be specified under `blobstore.s3_{signature_version,region}` or
  `agent.blobstore.s3_{signature_version,region}`
- Added testing for default values for the s3 blobstore properties
- Operator can specify AWS S3 region instead of the entire S3 host

[#111994203](https://www.pivotaltracker.com/story/show/111994203)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>