### PR TITLE
Add security group ids to port creation

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -189,11 +189,11 @@ module Bosh::OpenStackCloud
 
         network_configurator = NetworkConfigurator.new(network_spec)
 
-        security_groups_to_be_used = retrieve_and_validate_security_groups(network_configurator, resource_pool).map { |sg| sg.name }
-        @logger.debug("Using security groups: `#{security_groups_to_be_used.join(', ')}'")
+        security_groups_to_be_used = retrieve_and_validate_security_groups(network_configurator, resource_pool)
+        @logger.debug("Using security groups: `#{security_groups_to_be_used.map { |sg| sg.name }.join(', ')}'")
 
         if @config_drive
-          network_configurator.create_ports_for_manual_networks @openstack
+          network_configurator.create_ports_for_manual_networks @openstack, security_groups_to_be_used.map { |sg| sg.id }
         end
 
         nics = network_configurator.nics
@@ -239,7 +239,7 @@ module Bosh::OpenStackCloud
           :image_ref => image.id,
           :flavor_ref => flavor.id,
           :key_name => keyname,
-          :security_groups => security_groups_to_be_used,
+          :security_groups => security_groups_to_be_used.map { |sg| sg.name },
           :os_scheduler_hints => resource_pool['scheduler_hints'],
           :nics => nics,
           :config_drive => @use_config_drive,

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/network_configurator.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/network_configurator.rb
@@ -74,6 +74,8 @@ module Bosh::OpenStackCloud
                       "CPI can only handle `dynamic', 'manual' or `vip' " \
                       "network types")
       end
+
+      @security_groups.uniq!
     end
 
     ##
@@ -137,7 +139,7 @@ module Bosh::OpenStackCloud
     # Creates network ports via Neutron, if multiple manual networks
     # are configured.
     #
-    def create_ports_for_manual_networks(openstack)
+    def create_ports_for_manual_networks(openstack, security_group_ids)
       if multiple_manual_networks?
         @networks.each do |network_info|
           network = network_info['network']
@@ -145,7 +147,8 @@ module Bosh::OpenStackCloud
             port = with_openstack {
               openstack.network.ports.create({
                                                  network_id: network_info['net_id'],
-                                                 fixed_ips: [{ip_address: network.private_ip}]
+                                                 fixed_ips: [{ip_address: network.private_ip}],
+                                                 security_groups: security_group_ids
                                              })
             }
             network_info['port_id'] = port.id

--- a/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -357,7 +357,7 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
         end
 
         it 'calls NetworkConfigurator#prepare' do
-          expect_any_instance_of(Bosh::OpenStackCloud::NetworkConfigurator).to receive(:create_ports_for_manual_networks)
+          expect_any_instance_of(Bosh::OpenStackCloud::NetworkConfigurator).to receive(:create_ports_for_manual_networks).with(anything, ['default_sec_group_id'])
 
           cloud.create_vm("agent-id", "sc-id",
                           resource_pool_spec,
@@ -370,7 +370,7 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
         let(:cloud_options) { mock_cloud_options }
 
         it 'calls NetworkConfigurator#prepare' do
-          expect_any_instance_of(Bosh::OpenStackCloud::NetworkConfigurator).to_not receive(:create_ports_for_manual_networks)
+          expect_any_instance_of(Bosh::OpenStackCloud::NetworkConfigurator).to_not receive(:create_ports_for_manual_networks).with(anything, ['default_sec_group_id'])
 
           cloud.create_vm("agent-id", "sc-id",
                           resource_pool_spec,


### PR DESCRIPTION
- if a vm is created with an already existing network port
  the security groups of the port take precdence over
  those specified for the vm

[#114099831](https://www.pivotaltracker.com/story/show/114099831)

Signed-off-by: Beyhan Veli <beyhan.veli@sap.com>