### PR TITLE
use block_device_mapping_v2 instead of deprecated block_device_mapping

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -256,13 +256,12 @@ module Bosh::OpenStackCloud
         if @boot_from_volume
           boot_vol_size = flavor.disk * 1024
 
-          boot_vol_id = create_boot_disk(boot_vol_size, stemcell_id, availability_zone, @boot_volume_cloud_properties)
-          cloud_error("Failed to create boot volume.") if boot_vol_id.nil?
-          @logger.debug("Using boot volume: `#{boot_vol_id}'")
-
-          server_params[:block_device_mapping] = [{
+          server_params[:block_device_mapping_v2] = [{
+                                                   :uuid => image.id,
+                                                   :source_type => "image",
+                                                   :dest_type => "volume",
                                                    :volume_size => boot_vol_size,
-                                                   :volume_id => boot_vol_id,
+                                                   :boot_index => "0",
                                                    :delete_on_termination => "1",
                                                    :device_name => "/dev/vda"
                                                  }]

--- a/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -42,8 +42,12 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
     }
 
     if volume_id
-      params[:block_device_mapping] = [{ :volume_size => 2048,
-        :volume_id => volume_id,
+      params[:block_device_mapping_v2] = [{
+        :uuid => "sc-id",
+        :source_type => "image",
+        :dest_type => "volume",
+        :volume_size => 2048,
+        :boot_index => "0",
         :delete_on_termination => "1",
         :device_name => "/dev/vda" }]
     end
@@ -479,15 +483,13 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
         expect(openstack.servers).to receive(:create).with(openstack_params("network_a" => network_spec)).and_return(server)
         expect(openstack.images).to receive(:find).and_return(image)
         expect(openstack.flavors).to receive(:find).and_return(flavor)
-        expect(openstack.volumes).to receive(:create).with(disk_params).and_return(boot_volume)
         expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
         expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      expect(cloud).to receive(:generate_unique_name).exactly(2).times.and_return(unique_name, unique_vol_name)
+      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
       expect(address).to receive(:server=).with(nil)
       expect(cloud).to receive(:wait_resource).with(server, :active, :state)
-      expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
       expect(@registry).to receive(:update_settings).
         with("vm-#{unique_name}", agent_settings(unique_name, network_spec))
@@ -528,15 +530,13 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
         expect(openstack.servers).to receive(:create).with(openstack_params("network_a" => network_spec)).and_return(server)
         expect(openstack.images).to receive(:find).and_return(image)
         expect(openstack.flavors).to receive(:find).and_return(flavor)
-        expect(openstack.volumes).to receive(:create).with(disk_params).and_return(boot_volume)
         expect(openstack.key_pairs).to receive(:find).and_return(key_pair)
         expect(openstack.addresses).to receive(:each).and_yield(address)
       end
 
-      expect(cloud).to receive(:generate_unique_name).exactly(2).times.and_return(unique_name, unique_vol_name)
+      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
       expect(address).to receive(:server=).with(nil)
       expect(cloud).to receive(:wait_resource).with(server, :active, :state)
-      expect(cloud).to receive(:wait_resource).with(boot_volume, :available)
 
       expect(@registry).to receive(:update_settings).
         with("vm-#{unique_name}", agent_settings(unique_name, network_spec))


### PR DESCRIPTION
tested successfully on Icehouse (deploying BOSH from bosh-init & CF from BOSH) (with boot_from_volume: true of course):

```
Using boot parms: `{:name=>"vm-5e498960-a16e-4d5c-9d7d-72fa26451306", :image_ref=>"792115dd-126a-4031-bdb0-48f3b5a41920", :flavor_ref=>"c4f75bdb-a283-4b7e-829c-ddd6f1edcf23", :key_name=>"cf-keypair2", :security_groups=>["default", "cf-private", "bosh"], :os_scheduler_hints=>nil, :nics=>[{"net_id"=>"d261123e-3d69-41b0-a74b-34af85cb677f", "v4_fixed_ip"=>"192.168.0.2"}], :config_drive=>false, :user_data=>"{\"registry\":{\"endpoint\":\"http://127.0.0.1:6901\"},\"server\":{\"name\":\"vm-5e498960-a16e-4d5c-9d7d-72fa26451306\"},\"networks\":{\"private\":{\"cloud_properties\":{\"net_id\":\"d261123e-3d69-41b0-a74b-34af85cb677f\"},\"default\":[\"dns\",\"gateway\"],\"dns\":[\"xxx\"],\"gateway\":\"192.168.0.1\",\"ip\":\"192.168.0.2\",\"netmask\":\"255.255.255.0\",\"type\":\"manual\",\"use_dhcp\":true},\"public\":{\"cloud_properties\":{},\"ip\":\"xxx\",\"type\":\"vip\",\"use_dhcp\":true}},\"dns\":{\"nameserver\":[\"137.172.74.130\"]}}", :block_device_mapping_v2=>[{:uuid=>"792115dd-126a-4031-bdb0-48f3b5a41920", :source_type=>"image", :dest_type=>"volume", :volume_size=>20480, :boot_index=>"0", :delete_on_termination=>"1", :device_name=>"/dev/vda"}]}
```