### PR TITLE
Use `exec` to avoid second bash process

### DIFF
--- a/jobs/openstack_cpi/templates/cpi.erb
+++ b/jobs/openstack_cpi/templates/cpi.erb
@@ -27,8 +27,6 @@ export BUNDLE_GEMFILE=$BOSH_PACKAGES_DIR/bosh_openstack_cpi/Gemfile
 
 bundle_cmd="$BOSH_PACKAGES_DIR/ruby_openstack_cpi/bin/bundle"
 
-echo $INPUT | $bundle_cmd exec $BOSH_PACKAGES_DIR/bosh_openstack_cpi/bin/openstack_cpi \
-$BOSH_JOBS_DIR/openstack_cpi/config/cpi.json \
-$BOSH_JOBS_DIR/openstack_cpi/config/cacert.pem
-
-exit 0
+exec $bundle_cmd exec $BOSH_PACKAGES_DIR/bosh_openstack_cpi/bin/openstack_cpi \
+  $BOSH_JOBS_DIR/openstack_cpi/config/cpi.json \
+  $BOSH_JOBS_DIR/openstack_cpi/config/cacert.pem < <(echo $INPUT)


### PR DESCRIPTION
[#119609491](https://www.pivotaltracker.com/story/show/119609491)

Signed-off-by: Felix Riegger <felix.riegger@sap.com>