### PR TITLE
Fix stemcell hypervisor_type property

### DIFF
--- a/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
@@ -177,5 +177,33 @@ describe Bosh::OpenStackCloud::Cloud do
       end
     end
   end
+
+  describe :image_properties do
+    let(:cloud_options) { mock_cloud_options }
+    subject { Bosh::OpenStackCloud::Cloud.new(cloud_options['properties']) }
+
+    it 'rejects nil values and converts keys to symbols' do
+      properties = {
+        "name" => "name",
+        "version" => nil
+      }
+
+      image_properties = subject.normalize_image_properties(properties)
+
+      expect(image_properties).to have_key(:name)
+      expect(image_properties).to_not have_key(:version)
+    end
+
+    it 'maps hypervisor key to hypervisor_type' do
+      properties = {
+        "hypervisor" => "kvm"
+      }
+
+      image_properties = subject.normalize_image_properties(properties)
+
+      expect(image_properties[:hypervisor_type]).to eq("kvm")
+      expect(image_properties).to_not have_key(:hypervisor)
+    end
+  end
 end
 


### PR DESCRIPTION
The stemcell comes with the "hypervisor" attribute but glance expects
"hypervisor_type" instead.

[#121565957](https://www.pivotaltracker.com/story/show/121565957)

Signed-off-by: Mauro Morales <mamorales@suse.com>

fixes #39