### PR TITLE
Add support for Image and Volume V2 services

### DIFF
--- a/src/bosh_openstack_cpi/Gemfile
+++ b/src/bosh_openstack_cpi/Gemfile
@@ -13,4 +13,5 @@ group :development, :test do
   gem 'minitar', '~> 0.5.4'
   gem 'timecop', '~>0.7.1'
   gem 'rake', '~>10.3.2'
+  gem 'webmock', '~>2.1.0'
 end

--- a/src/bosh_openstack_cpi/Gemfile.lock
+++ b/src/bosh_openstack_cpi/Gemfile.lock
@@ -1,6 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.4.0)
     bosh_common (1.3215.3.0)
       logging (~> 1.8.2)
       semi_semantic (~> 1.1.0)
@@ -8,6 +9,8 @@ GEM
       logging (~> 1.8.2)
       membrane (~> 1.1.0)
     builder (3.2.2)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     excon (0.49.0)
     fog-core (1.40.0)
@@ -22,6 +25,7 @@ GEM
       fog-json (>= 1.0)
       ipaddress (>= 0.8)
     formatador (0.2.5)
+    hashdiff (0.3.0)
     httpclient (2.7.1)
     ipaddress (0.8.3)
     little-plugger (1.1.4)
@@ -47,8 +51,13 @@ GEM
     rspec-mocks (3.0.4)
       rspec-support (~> 3.0.0)
     rspec-support (3.0.4)
+    safe_yaml (1.0.4)
     semi_semantic (1.1.0)
     timecop (0.7.4)
+    webmock (2.1.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -65,6 +74,7 @@ DEPENDENCIES
   rspec (~> 3.0.0)
   rspec-its (~> 1.0.1)
   timecop (~> 0.7.1)
+  webmock (~> 2.1.0)
 
 BUNDLED WITH
    1.12.5

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -115,7 +115,7 @@ module Bosh::OpenStackCloud
 
             is_public = !@stemcell_public_visibility.nil? && @stemcell_public_visibility.to_s != 'false'
             if is_glance_v1
-              image_params[:is_public] = is_public.to_s
+              image_params[:is_public] = is_public
             else
               image_params[:visibility] = is_public ? 'public' : 'private'
             end

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/helpers.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/helpers.rb
@@ -123,16 +123,11 @@ module Bosh::OpenStackCloud
         # If resource reload is nil, perhaps it's because resource went away
         # (ie: a destroy operation). Don't raise an exception if this is
         # expected (allow_notfound).
-        begin
-          if with_openstack { resource.reload.nil? }
-            break if allow_notfound
-            cloud_error("#{desc}: Resource not found")
-          else
-            state =  with_openstack { resource.send(state_method).downcase.to_sym }
-          end
-        rescue Bosh::Clouds::CloudError => e
-          break if allow_notfound && e.message.match(/not found error/)
+        if with_openstack { resource.reload.nil? }
+          break if allow_notfound
           cloud_error("#{desc}: Resource not found")
+        else
+          state =  with_openstack { resource.send(state_method).downcase.to_sym }
         end
 
         # This is not a very strong convention, but some resources

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/openstack.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/openstack.rb
@@ -1,4 +1,30 @@
 require 'common/common'
+require 'fog/openstack/models/model'
+require 'fog/openstack/models/image_v2/image'
+require 'fog/openstack/models/image_v2/images'
+
+# TODO: remove these patches once https://github.com/fog/fog-openstack/pull/170 is merged
+# image_v2 disabled the `identity` method to workaround around a bug
+# where image.save would call update instead of create on a new image if the user
+# explicitly set an ID.
+# The removal of `identity` breaks the `reload` our waiters use for all resources.
+# As the CPI does not set ID on create, we can monkeypatch image_v2 to call through
+# to original implementation of `identity` until a fix is added upstream.
+module FogImagePatch
+  def identity
+    Fog::Model.instance_method(:identity).bind(self).call
+  end
+end
+Fog::Image::OpenStack::V2::Image.prepend FogImagePatch
+# image_v2 also breaks `reload` for images fetched via `images.get(image_id)`
+# as the image.collection is nil
+module FogImagesPatch
+  def find_by_id(id)
+    all.find {|image| image.id == id}
+  end
+  alias_method :get, :find_by_id
+end
+Fog::Image::OpenStack::V2::Images.prepend FogImagesPatch
 
 module Bosh::OpenStackCloud
   class Openstack
@@ -51,7 +77,12 @@ module Bosh::OpenStackCloud
         begin
           Bosh::Common.retryable(@connect_retry_options) do |tries, error|
             @logger.error("Failed #{tries} times, last failure due to: #{error.inspect}") unless error.nil?
-            @glance = Fog::Image::OpenStack::V1.new(params_without_provider)
+
+            begin
+              @glance = Fog::Image::OpenStack::V2.new(params_without_provider)
+            rescue Fog::OpenStack::Errors::ServiceUnavailable
+              @glance = Fog::Image::OpenStack::V1.new(params_without_provider)
+            end
           end
         rescue Excon::Errors::SocketError => e
           cloud_error(socket_error_msg + "#{e.message}")
@@ -72,7 +103,11 @@ module Bosh::OpenStackCloud
         begin
           Bosh::Common.retryable(@connect_retry_options) do |tries, error|
             @logger.error("Failed #{tries} times, last failure due to: #{error.inspect}") unless error.nil?
-            @volume ||= Fog::Volume::OpenStack::V1.new(params_without_provider)
+            begin
+              @volume = Fog::Volume::OpenStack::V2.new(params_without_provider)
+            rescue Fog::OpenStack::Errors::ServiceUnavailable, Fog::Errors::NotFound
+              @volume = Fog::Volume::OpenStack::V1.new(params_without_provider)
+            end
           end
         rescue Excon::Errors::SocketError => e
           cloud_error(socket_error_msg + "#{e.message}")

--- a/src/bosh_openstack_cpi/spec/integration/image_spec.rb
+++ b/src/bosh_openstack_cpi/spec/integration/image_spec.rb
@@ -1,0 +1,114 @@
+require 'integration/spec_helper'
+require 'cloud'
+require 'logger'
+require 'net/http'
+
+describe Bosh::OpenStackCloud::Cloud do
+  include Bosh::OpenStackCloud::Helpers
+
+  before(:all) do
+    @auth_url                        = LifecycleHelper.get_config(:auth_url_v2)
+    @username                        = LifecycleHelper.get_config(:username)
+    @api_key                         = LifecycleHelper.get_config(:api_key)
+    @tenant                          = LifecycleHelper.get_config(:tenant)
+    @stemcell_path                   = LifecycleHelper.get_config(:stemcell_path)
+    @default_key_name                = LifecycleHelper.get_config(:default_key_name)
+    @ignore_server_az                = LifecycleHelper.get_config(:ignore_server_az, 'false')
+  end
+
+  def create_cpi
+    described_class.new(
+      'openstack' => {
+        'auth_url' => @auth_url,
+        'username' => @username,
+        'api_key' => @api_key,
+        'tenant' => @tenant,
+        'region' => @region,
+        'endpoint_type' => 'publicURL',
+        'default_key_name' => @default_key_name,
+        'default_security_groups' => %w(default),
+        'wait_resource_poll_interval' => 5,
+        'boot_from_volume' => false,
+        'config_drive' => nil,
+        'ignore_server_availability_zone' => str_to_bool(@ignore_server_az),
+        'human_readable_vm_names' => false,
+        'connection_options' => connection_options(additional_connection_options(@logger))
+      },
+      'registry' => {
+        'endpoint' => 'fake',
+        'user' => 'fake',
+        'password' => 'fake'
+      }
+    )
+  end
+
+  let(:logger) { Logger.new(STDERR) }
+
+  before do
+    delegate = double('delegate', logger: logger, cpi_task_log: nil)
+    Bosh::Clouds::Config.configure(delegate)
+    allow(Bosh::Clouds::Config).to receive(:logger).and_return(logger)
+  end
+
+  describe 'Glance V2 support' do
+    let(:cpi_for_stemcell) { create_cpi }
+
+    before do
+      expect(cpi_for_stemcell.glance.class.to_s).to start_with('Fog::Image::OpenStack::V2')
+    end
+
+    it 'uploads and deletes a stemcell' do
+      stemcell_manifest = Psych.load_file(File.join(@stemcell_path, 'stemcell.MF'))
+      stemcell_id = cpi_for_stemcell.create_stemcell(File.join(@stemcell_path, 'image'), stemcell_manifest['cloud_properties'])
+      expect(stemcell_id).to_not be_nil
+
+      image = cpi_for_stemcell.glance.images.get(stemcell_id)
+      expect(image).to_not be_nil
+      expect(image.name).to eq("#{stemcell_manifest['cloud_properties']['name']}/#{stemcell_manifest['cloud_properties']['version']}")
+      expect(image.visibility).to eq('private')
+      expect(image.os_distro).to eq('ubuntu')
+
+      cpi_for_stemcell.delete_stemcell(stemcell_id)
+      wait_resource(image, :deleted, :status, true)
+    end
+  end
+
+  describe 'Glance V1 support' do
+    let(:cpi_for_stemcell) { create_cpi }
+
+    before do
+      force_image_v1
+    end
+
+    it 'uploads and deletes a stemcell' do
+      stemcell_manifest = Psych.load_file(File.join(@stemcell_path, 'stemcell.MF'))
+      stemcell_id = cpi_for_stemcell.create_stemcell(File.join(@stemcell_path, 'image'), stemcell_manifest['cloud_properties'])
+      expect(stemcell_id).to_not be_nil
+
+      image = cpi_for_stemcell.glance.images.get(stemcell_id)
+      expect(image).to_not be_nil
+      expect(image.name).to eq("#{stemcell_manifest['cloud_properties']['name']}/#{stemcell_manifest['cloud_properties']['version']}")
+      expect(image.is_public).to be(false)
+      expect(image.properties).to include('os_distro' => 'ubuntu')
+
+      cpi_for_stemcell.delete_stemcell(stemcell_id)
+      wait_resource(image, :deleted, :status, true)
+    end
+  end
+
+  def force_image_v1
+    LifecycleHelper.override_root_service_versions(auth_url: @auth_url, port: 9292) do |versions|
+      versions.select { |v| v['id'].start_with?('v1.') }
+    end
+
+    expect(cpi_for_stemcell.glance.class.to_s).to start_with('Fog::Image::OpenStack::V1')
+  end
+
+  def str_to_bool(string)
+    if string == 'true'
+      true
+    else
+      false
+    end
+  end
+end

--- a/src/bosh_openstack_cpi/spec/integration/spec_helper.rb
+++ b/src/bosh_openstack_cpi/spec/integration/spec_helper.rb
@@ -1,0 +1,6 @@
+require 'spec_helper'
+require 'webmock/rspec'
+
+RSpec.configure do |config|
+  config.before(:all) { WebMock.allow_net_connect! }
+end

--- a/src/bosh_openstack_cpi/spec/integration/volume_spec.rb
+++ b/src/bosh_openstack_cpi/spec/integration/volume_spec.rb
@@ -1,0 +1,168 @@
+require 'integration/spec_helper'
+require 'cloud'
+require 'logger'
+require 'net/http'
+
+describe Bosh::OpenStackCloud::Cloud do
+  include Bosh::OpenStackCloud::Helpers
+
+  before(:all) do
+    @logger                          = Logger.new(STDERR)
+    @auth_url                        = LifecycleHelper.get_config(:auth_url_v2)
+    @username                        = LifecycleHelper.get_config(:username)
+    @api_key                         = LifecycleHelper.get_config(:api_key)
+    @tenant                          = LifecycleHelper.get_config(:tenant)
+    @stemcell_path                   = LifecycleHelper.get_config(:stemcell_path)
+    @default_key_name                = LifecycleHelper.get_config(:default_key_name)
+    @ignore_server_az                = LifecycleHelper.get_config(:ignore_server_az, 'false')
+    @instance_type                   = LifecycleHelper.get_config(:instance_type, 'm1.small')
+    @net_id                          = LifecycleHelper.get_config(:net_id)
+    @volume_type                     = LifecycleHelper.get_config(:volume_type, nil)
+
+    Bosh::Clouds::Config.configure(OpenStruct.new(:logger => @logger, :cpi_task_log => nil))
+    @cpi_for_stemcell                = create_cpi
+    @stemcell_id                     = upload_stemcell
+  end
+
+  after(:all) do
+    @cpi_for_stemcell.delete_stemcell(@stemcell_id)
+  end
+
+  before { allow(Bosh::Cpi::RegistryClient).to receive(:new).and_return(double('registry').as_null_object) }
+
+  def create_cpi
+    described_class.new(
+      'openstack' => {
+        'auth_url' => @auth_url,
+        'username' => @username,
+        'api_key' => @api_key,
+        'tenant' => @tenant,
+        'region' => @region,
+        'endpoint_type' => 'publicURL',
+        'default_key_name' => @default_key_name,
+        'default_security_groups' => %w(default),
+        'wait_resource_poll_interval' => 5,
+        'boot_from_volume' => false,
+        'config_drive' => nil,
+        'ignore_server_availability_zone' => str_to_bool(@ignore_server_az),
+        'human_readable_vm_names' => false,
+        'connection_options' => connection_options(additional_connection_options(@logger))
+      },
+      'registry' => {
+        'endpoint' => 'fake',
+        'user' => 'fake',
+        'password' => 'fake'
+      }
+    )
+  end
+
+  def upload_stemcell
+    stemcell_manifest = Psych.load_file(File.join(@stemcell_path, 'stemcell.MF'))
+    @cpi_for_stemcell.create_stemcell(File.join(@stemcell_path, 'image'), stemcell_manifest['cloud_properties'])
+  end
+
+  let(:disk_snapshot_metadata) do
+    {
+      :deployment => 'deployment',
+      :job => 'openstack_cpi_spec',
+      :index => '0',
+      :instance_id => 'instance',
+      :agent_id => 'agent',
+      :director_name => 'Director',
+      :director_uuid => '6d06b0cc-2c08-43c5-95be-f1b2dd247e18',
+    }
+  end
+
+  let(:cpi_for_volume) { create_cpi }
+
+  let(:cpi_for_vm) { create_cpi }
+
+  let(:network_spec) do
+    {
+      'default' => {
+        'type' => 'dynamic',
+        'cloud_properties' => {
+          'net_id' => @net_id
+        }
+      }
+    }
+  end
+
+  let(:vm_id) do
+    cpi_for_vm.create_vm(
+      'agent-007',
+      @stemcell_id,
+      { 'instance_type' => @instance_type },
+      network_spec,
+      [],
+      { 'key' => 'value' }
+    )
+  end
+
+  let(:cloud_properties) { { 'type' => @volume_type } }
+
+  after(:each) do
+    cpi_for_vm.delete_vm(vm_id)
+  end
+
+  describe 'Cinder V2 support' do
+    before do
+      expect(cpi_for_volume.volume.class.to_s).to start_with('Fog::Volume::OpenStack::V2')
+    end
+
+    it 'exercises the volume lifecycle' do
+      volume_lifecycle
+    end
+  end
+
+  describe 'Cinder V1 support' do
+    before do
+      force_volume_v1
+    end
+
+    it 'exercises the volume lifecycle' do
+      volume_lifecycle
+    end
+  end
+
+  def volume_lifecycle
+    expect(vm_id).to_not be_nil
+
+    disk_id = cpi_for_volume.create_disk(2048, cloud_properties, vm_id)
+    expect(disk_id).to be
+
+    expect(cpi_for_volume.has_disk?(disk_id)).to be(true)
+
+    cpi_for_volume.attach_disk(vm_id, disk_id)
+
+    disk_snapshot_id = cpi_for_volume.snapshot_disk(disk_id, disk_snapshot_metadata)
+    expect(disk_snapshot_id).to be
+
+    cpi_for_volume.delete_snapshot(disk_snapshot_id)
+
+    cpi_for_volume.detach_disk(vm_id, disk_id)
+
+    cpi_for_volume.delete_disk(disk_id)
+  end
+
+  def force_volume_v1
+    LifecycleHelper.override_root_service_versions(port: 8776, auth_url: @auth_url) do |versions|
+      versions.select { |v| v['id'].start_with?('v1.') }
+    end
+    connection_opts = {auth_url: @auth_url, tenant: @tenant, username: @username, api_key: @api_key}
+    LifecycleHelper.override_token_v2_service_catalog(connection_opts) do |service_catalog|
+      volume_v1_type = 'volume'
+      service_catalog.reject { |service| service['type'].start_with?('volume') && service['type'] != volume_v1_type }
+    end
+
+    expect(cpi_for_volume.volume.class.to_s).to start_with('Fog::Volume::OpenStack::V1')
+  end
+
+  def str_to_bool(string)
+    if string == 'true'
+      true
+    else
+      false
+    end
+  end
+end

--- a/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/cloud_spec.rb
@@ -192,10 +192,10 @@ describe Bosh::OpenStackCloud::Cloud do
 
     it 'converts keys to symbols' do
       properties = {
-        "name" => "name",
+        "version" => "123",
       }
 
-      expect(subject.normalize_image_properties(properties)).to have_key(:name)
+      expect(subject.normalize_image_properties(properties)).to have_key(:version)
     end
 
     it 'maps hypervisor key to hypervisor_type' do

--- a/src/bosh_openstack_cpi/spec/unit/create_disk_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/create_disk_spec.rb
@@ -6,7 +6,9 @@ describe Bosh::OpenStackCloud::Cloud do
       unique_name = SecureRandom.uuid
       disk_params = {
         :display_name => "volume-#{unique_name}",
-        :display_description => "",
+        :display_description => '',
+        :name => "volume-#{unique_name}",
+        :description => '',
         :size => 2
       }
       volume = double("volume", :id => "v-foobar")
@@ -19,7 +21,7 @@ describe Bosh::OpenStackCloud::Cloud do
       allow(cloud).to receive(:generate_unique_name).and_return(unique_name)
       allow(cloud).to receive(:wait_resource).with(volume, :available)
 
-      expect(Fog::Volume::OpenStack::V1).to receive(:new)
+      expect(Fog::Volume::OpenStack::V2).to receive(:new)
       expect(cloud.create_disk(2048, {})).to eq("v-foobar")
     end
   end
@@ -29,6 +31,8 @@ describe Bosh::OpenStackCloud::Cloud do
     disk_params = {
       :display_name => "volume-#{unique_name}",
       :display_description => "",
+      :name => "volume-#{unique_name}",
+      :description => "",
       :size => 2
     }
     volume = double("volume", :id => "v-foobar")
@@ -49,6 +53,8 @@ describe Bosh::OpenStackCloud::Cloud do
     disk_params = {
       :display_name => "volume-#{unique_name}",
       :display_description => "",
+      :name => "volume-#{unique_name}",
+      :description => "",
       :size => 2,
       :volume_type => "foo"
     }
@@ -70,6 +76,8 @@ describe Bosh::OpenStackCloud::Cloud do
     disk_params = {
       :display_name => "volume-#{unique_name}",
       :display_description => "",
+      :name => "volume-#{unique_name}",
+      :description => "",
       :size => 3
     }
     volume = double("volume", :id => "v-foobar")
@@ -96,6 +104,8 @@ describe Bosh::OpenStackCloud::Cloud do
     disk_params = {
       :display_name => "volume-#{unique_name}",
       :display_description => "",
+      :name => "volume-#{unique_name}",
+      :description => "",
       :size => 1,
       :availability_zone => "foobar-land"
     }
@@ -121,6 +131,8 @@ describe Bosh::OpenStackCloud::Cloud do
     disk_params = {
         :display_name => "volume-#{unique_name}",
         :display_description => "",
+        :name => "volume-#{unique_name}",
+        :description => "",
         :size => 1
     }
     server = double("server", :id => "i-test",

--- a/src/bosh_openstack_cpi/spec/unit/create_stemcell_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/create_stemcell_spec.rb
@@ -4,217 +4,398 @@
 require 'spec_helper'
 
 describe Bosh::OpenStackCloud::Cloud do
-  let(:image) { double('image', :id => 'i-bar', :name => 'i-bar') }
+  let(:image) { double('image', :id => 'i-bar') }
   let(:unique_name) { SecureRandom.uuid }
 
   before { @tmp_dir = Dir.mktmpdir }
 
   describe 'Image upload based flow' do
-    it 'creates stemcell using a stemcell file' do
-      image_params = {
-        :name => "BOSH-#{unique_name}",
-        :disk_format => 'qcow2',
-        :container_format => 'bare',
-        :location => "#{@tmp_dir}/root.img",
-        :is_public => false
-      }
 
-      cloud = mock_glance do |glance|
-        expect(glance.images).to receive(:create).with(image_params).and_return(image)
+    let(:cloud_options) { nil }
+
+    context 'when an environment only supports image v1' do
+
+      before do
+        @cloud = mock_glance_v1(cloud_options) do |glance|
+          @glance = glance
+        end
       end
 
-      expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
-      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
-      expect(cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
-      expect(cloud).to receive(:wait_resource).with(image, :active)
-
-      sc_id = cloud.create_stemcell('/tmp/foo', {
-        'container_format' => 'bare',
-        'disk_format' => 'qcow2'
-      })
-
-      expect(sc_id).to eq 'i-bar'
-    end
-
-    it 'creates stemcell using a remote stemcell file' do
-      image_params = {
-        :name => "BOSH-#{unique_name}",
-        :disk_format => 'qcow2',
-        :container_format => 'bare',
-        :copy_from => 'http://cloud-images.ubuntu.com/bosh/root.img',
-        :is_public => false
-      }
-
-      cloud = mock_glance do |glance|
-        expect(glance.images).to receive(:create).with(image_params).and_return(image)
-      end
-
-      expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
-      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
-      expect(cloud).to_not receive(:unpack_image)
-      expect(cloud).to receive(:wait_resource).with(image, :active)
-
-      sc_id = cloud.create_stemcell('/tmp/foo', {
-        'container_format' => 'bare',
-        'disk_format' => 'qcow2',
-        'image_location' => 'http://cloud-images.ubuntu.com/bosh/root.img'
-      })
-
-      expect(sc_id).to eq 'i-bar'
-    end
-
-    it 'sets image properties from cloud_properties' do
-      image_params = {
-        :name => "BOSH-#{unique_name}",
-        :disk_format => 'qcow2',
-        :container_format => 'bare',
-        :location => "#{@tmp_dir}/root.img",
-        :is_public => false,
-        :properties => {
-          :name => 'stemcell-name',
-          :version => 'x.y.z',
-          :os_type => 'linux',
-          :os_distro => 'ubuntu',
-          :architecture => 'x86_64',
-          :auto_disk_config => 'true'
+      it 'creates stemcell using a stemcell file' do
+        image_params = {
+          name: 'stemcell-name/x.y.z',
+          disk_format: 'qcow2',
+          container_format: 'bare',
+          location: "#{@tmp_dir}/root.img",
+          is_public: 'false',
+          properties: {
+            version: 'x.y.z'
+          }
         }
-      }
 
-      cloud = mock_glance do |glance|
-        expect(glance.images).to receive(:create).with(image_params).and_return(image)
-      end
+        expect(@glance.images).to receive(:create).with(image_params).and_return(image)
 
-      expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
-      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
-      expect(cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
-      expect(cloud).to receive(:wait_resource).with(image, :active)
+        expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+        expect(@cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
+        expect(@cloud).to receive(:wait_resource).with(image, :active)
 
-      sc_id = cloud.create_stemcell('/tmp/foo', {
-        'name' => 'stemcell-name',
-        'version' => 'x.y.z',
-        'os_type' => 'linux',
-        'os_distro' => 'ubuntu',
-        'architecture' => 'x86_64',
-        'auto_disk_config' => 'true',
-        'foo' => 'bar',
-        'container_format' => 'bare',
-        'disk_format' => 'qcow2',
-      })
-
-      expect(sc_id).to eq 'i-bar'
-    end
-
-    it 'passes through whitelisted glance properties from cloud_properties to glance when making a stemcell' do
-      extra_properties = {
-        'name' => 'stemcell-name',
-        'version' => 'x.y.z',
-        'os_type' => 'linux',
-        'os_distro' => 'ubuntu',
-        'architecture' => 'x86_64',
-        'auto_disk_config' => 'true',
-        'foo' => 'bar',
-        'container_format' => 'bare',
-        'disk_format' => 'qcow2',
-        'hw_vif_model' => 'fake-hw_vif_model',
-        'hypervisor' => 'fake-hypervisor_type',
-        'vmware_adaptertype' => 'fake-vmware_adaptertype',
-        'vmware_disktype' => 'fake-vmware_disktype',
-        'vmware_linked_clone' => 'fake-vmware_linked_clone',
-        'vmware_ostype' => 'fake-vmware_ostype',
-      }
-
-      image_params = {
-        :name => "BOSH-#{unique_name}",
-        :disk_format => 'qcow2',
-        :container_format => 'bare',
-        :location => "#{@tmp_dir}/root.img",
-        :is_public => false,
-        :properties => {
-          :name => 'stemcell-name',
-          :version => 'x.y.z',
-          :os_type => 'linux',
-          :os_distro => 'ubuntu',
-          :architecture => 'x86_64',
-          :auto_disk_config => 'true',
-          :hw_vif_model => 'fake-hw_vif_model',
-          :hypervisor_type => 'fake-hypervisor_type',
-          :vmware_adaptertype => 'fake-vmware_adaptertype',
-          :vmware_disktype => 'fake-vmware_disktype',
-          :vmware_linked_clone => 'fake-vmware_linked_clone',
-          :vmware_ostype => 'fake-vmware_ostype',
-        }
-      }
-
-      cloud = mock_glance do |glance|
-        expect(glance.images).to receive(:create).with(image_params).and_return(image)
-      end
-      allow(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
-      allow(cloud).to receive(:generate_unique_name).and_return(unique_name)
-      allow(cloud).to receive(:unpack_image)
-      allow(cloud).to receive(:wait_resource)
-
-      cloud.create_stemcell('/tmp/foo', extra_properties)
-    end
-
-    it 'sets stemcell visibility to public when required' do
-      image_params = {
-        :name => "BOSH-#{unique_name}",
-        :disk_format => 'qcow2',
-        :container_format => 'bare',
-        :location => "#{@tmp_dir}/root.img",
-        :is_public => true,
-      }
-
-      cloud_options = mock_cloud_options['properties']
-      cloud_options['openstack']['stemcell_public_visibility'] = true
-      cloud = mock_glance(cloud_options) do |glance|
-        expect(glance.images).to receive(:create).with(image_params).and_return(image)
-      end
-
-      expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
-      expect(cloud).to receive(:generate_unique_name).and_return(unique_name)
-      expect(cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
-      expect(cloud).to receive(:wait_resource).with(image, :active)
-
-      sc_id = cloud.create_stemcell('/tmp/foo', {
-        'container_format' => 'bare',
-        'disk_format' => 'qcow2',
-      })
-
-      expect(sc_id).to eq 'i-bar'
-    end
-
-    it 'should throw an error for non existent root image in stemcell archive' do
-      result = Bosh::Exec::Result.new('cmd', 'output', 0)
-      expect(Bosh::Exec).to receive(:sh).and_return(result)
-
-      cloud = mock_glance
-
-      allow(File).to receive(:exists?).and_return(false)
-
-      expect {
-        cloud.create_stemcell('/tmp/foo', {
+        sc_id = @cloud.create_stemcell('/tmp/foo', {
+          'name' => 'stemcell-name',
+          'version' => 'x.y.z',
           'container_format' => 'bare',
           'disk_format' => 'qcow2'
         })
-      }.to raise_exception(Bosh::Clouds::CloudError, 'Root image is missing from stemcell archive')
-    end
 
-    it 'should fail if cannot extract root image' do
-      result = Bosh::Exec::Result.new('cmd', 'output', 1)
-      expect(Bosh::Exec).to receive(:sh).and_return(result)
+        expect(sc_id).to eq 'i-bar'
+      end
 
-      cloud = mock_glance
+      it 'sets image properties from cloud_properties' do
+        image_params = {
+          name: 'stemcell-name/x.y.z',
+          disk_format: 'qcow2',
+          container_format: 'bare',
+          location: "#{@tmp_dir}/root.img",
+          is_public: 'false',
+          properties: {
+            version: 'x.y.z',
+            os_type: 'linux',
+            os_distro: 'ubuntu',
+            architecture: 'x86_64',
+            auto_disk_config: 'true'
+          }
+        }
 
-      expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+        expect(@glance.images).to receive(:create).with(image_params).and_return(image)
 
-      expect {
-        cloud.create_stemcell('/tmp/foo', {
-          'container_format' => 'ami',
-          'disk_format' => 'ami'
+        expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+        expect(@cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
+        expect(@cloud).to receive(:wait_resource).with(image, :active)
+
+        sc_id = @cloud.create_stemcell('/tmp/foo', {
+          'name' => 'stemcell-name',
+          'version' => 'x.y.z',
+          'os_type' => 'linux',
+          'os_distro' => 'ubuntu',
+          'architecture' => 'x86_64',
+          'auto_disk_config' => 'true',
+          'foo' => 'bar',
+          'container_format' => 'bare',
+          'disk_format' => 'qcow2',
         })
-      }.to raise_exception(Bosh::Clouds::CloudError,
-        'Extracting stemcell root image failed. Check task debug log for details.')
+
+        expect(sc_id).to eq 'i-bar'
+      end
+
+      it 'passes through whitelisted glance properties from cloud_properties to glance when making a stemcell' do
+        extra_properties = {
+          'name' => 'stemcell-name',
+          'version' => 'x.y.z',
+          'os_type' => 'linux',
+          'os_distro' => 'ubuntu',
+          'architecture' => 'x86_64',
+          'auto_disk_config' => 'true',
+          'foo' => 'bar',
+          'container_format' => 'bare',
+          'disk_format' => 'qcow2',
+          'hw_vif_model' => 'fake-hw_vif_model',
+          'hypervisor' => 'fake-hypervisor_type', # hypervisor turns into hypervisor_type
+        }
+
+        image_params = {
+          name: 'stemcell-name/x.y.z',
+          disk_format: 'qcow2',
+          container_format: 'bare',
+          location: "#{@tmp_dir}/root.img",
+          is_public: 'false',
+          properties: {
+            version: 'x.y.z',
+            os_type: 'linux',
+            os_distro: 'ubuntu',
+            architecture: 'x86_64',
+            auto_disk_config: 'true',
+            hw_vif_model: 'fake-hw_vif_model',
+            hypervisor_type: 'fake-hypervisor_type',
+          }
+        }
+
+        expect(@glance.images).to receive(:create).with(image_params).and_return(image)
+
+        allow(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+        allow(@cloud).to receive(:unpack_image)
+        allow(@cloud).to receive(:wait_resource)
+
+        @cloud.create_stemcell('/tmp/foo', extra_properties)
+      end
+
+      it 'should throw an error for non existent root image in stemcell archive' do
+        result = Bosh::Exec::Result.new('cmd', 'output', 0)
+        expect(Bosh::Exec).to receive(:sh).and_return(result)
+
+        allow(File).to receive(:exists?).and_return(false)
+
+        expect {
+          @cloud.create_stemcell('/tmp/foo', {
+            'container_format' => 'bare',
+            'disk_format' => 'qcow2'
+          })
+        }.to raise_exception(Bosh::Clouds::CloudError, 'Root image is missing from stemcell archive')
+      end
+
+      it 'should fail if cannot extract root image' do
+        result = Bosh::Exec::Result.new('cmd', 'output', 1)
+        expect(Bosh::Exec).to receive(:sh).and_return(result)
+
+        expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+
+        expect {
+          @cloud.create_stemcell('/tmp/foo', {
+            'container_format' => 'ami',
+            'disk_format' => 'ami'
+          })
+        }.to raise_exception(Bosh::Clouds::CloudError,
+          'Extracting stemcell root image failed. Check task debug log for details.')
+      end
+
+      context 'stemcell_public_visibility is true' do
+
+        let(:cloud_options) do
+          cloud_options = mock_cloud_options['properties']
+          cloud_options['openstack']['stemcell_public_visibility'] = true
+          cloud_options
+        end
+
+        it 'sets stemcell visibility to public when required' do
+          image_params = {
+            name: 'stemcell-name/x.y.z',
+            disk_format: 'qcow2',
+            container_format: 'bare',
+            location: "#{@tmp_dir}/root.img",
+            is_public: 'true',
+            properties: {
+              version: 'x.y.z'
+            }
+          }
+
+          expect(@glance.images).to receive(:create).with(image_params).and_return(image)
+
+          expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+          expect(@cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
+          expect(@cloud).to receive(:wait_resource).with(image, :active)
+
+          sc_id = @cloud.create_stemcell('/tmp/foo', {
+            'name' => 'stemcell-name',
+            'version' => 'x.y.z',
+            'container_format' => 'bare',
+            'disk_format' => 'qcow2',
+          })
+
+          expect(sc_id).to eq 'i-bar'
+        end
+      end
+
     end
+
+    context 'when an environment supports image v2' do
+
+      before do
+        @cloud = mock_glance_v2(cloud_options) do |glance|
+          @glance = glance
+        end
+      end
+
+      it 'creates an image and uploads data using a stemcell file' do
+        image_params = {
+          name: 'stemcell-name/x.y.z',
+          disk_format: 'qcow2',
+          container_format: 'bare',
+          visibility: 'private',
+          version: 'x.y.z',
+        }
+
+        expect(@glance.images).to receive(:create).with(image_params).and_return(image)
+
+        expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+        expect(@cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
+        expect(@cloud).to receive(:wait_resource).with(image, :queued)
+
+        fake_file = double(File)
+
+        expect(File).to receive(:open).with("#{@tmp_dir}/root.img", 'rb').and_return(fake_file)
+
+        expect(image).to receive(:upload_data).with(fake_file)
+
+        expect(@cloud).to receive(:wait_resource).with(image, :active)
+
+        sc_id = @cloud.create_stemcell('/tmp/foo', {
+          'name' => 'stemcell-name',
+          'version' => 'x.y.z',
+          'container_format' => 'bare',
+          'disk_format' => 'qcow2'
+        })
+
+        expect(sc_id).to eq 'i-bar'
+      end
+
+      it 'sets custom image properties from cloud_properties' do
+        image_params = {
+          name: 'stemcell-name/x.y.z',
+          disk_format: 'qcow2',
+          container_format: 'bare',
+          visibility: 'private',
+          version: 'x.y.z',
+          os_type: 'linux',
+          os_distro: 'ubuntu',
+          architecture: 'x86_64',
+          auto_disk_config: 'true',
+        }
+
+        expect(@glance.images).to receive(:create).with(image_params).and_return(image)
+
+        expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+        expect(@cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
+        expect(@cloud).to receive(:wait_resource).with(image, :queued)
+
+        fake_file = double(File)
+
+        expect(File).to receive(:open).with("#{@tmp_dir}/root.img", 'rb').and_return(fake_file)
+
+        expect(image).to receive(:upload_data).with(fake_file)
+
+        expect(@cloud).to receive(:wait_resource).with(image, :active)
+
+        sc_id = @cloud.create_stemcell('/tmp/foo', {
+          'name' => 'stemcell-name',
+          'version' => 'x.y.z',
+          'os_type' => 'linux',
+          'os_distro' => 'ubuntu',
+          'architecture' => 'x86_64',
+          'auto_disk_config' => 'true',
+          'foo' => 'bar',
+          'container_format' => 'bare',
+          'disk_format' => 'qcow2',
+        })
+
+        expect(sc_id).to eq 'i-bar'
+      end
+
+      it 'passes through whitelisted glance properties from cloud_properties to glance when making a stemcell' do
+        extra_properties = {
+          'name' => 'stemcell-name',
+          'version' => 'x.y.z',
+          'os_type' => 'linux',
+          'os_distro' => 'ubuntu',
+          'architecture' => 'x86_64',
+          'auto_disk_config' => 'true',
+          'foo' => 'bar',
+          'container_format' => 'bare',
+          'disk_format' => 'qcow2',
+          'hw_vif_model' => 'fake-hw_vif_model',
+          'hypervisor' => 'fake-hypervisor_type', # hypervisor turns into hypervisor_type
+        }
+
+        image_params = {
+          name: 'stemcell-name/x.y.z',
+          disk_format: 'qcow2',
+          container_format: 'bare',
+          visibility: 'private',
+          version: 'x.y.z',
+          os_type: 'linux',
+          os_distro: 'ubuntu',
+          architecture: 'x86_64',
+          auto_disk_config: 'true',
+          hw_vif_model: 'fake-hw_vif_model',
+          hypervisor_type: 'fake-hypervisor_type',
+        }
+
+        expect(@glance.images).to receive(:create).with(image_params).and_return(image)
+
+        allow(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+        allow(@cloud).to receive(:unpack_image)
+        allow(@cloud).to receive(:wait_resource).with(image, :queued)
+
+        fake_file = double(File)
+        expect(File).to receive(:open).with("#{@tmp_dir}/root.img", 'rb').and_return(fake_file)
+        expect(image).to receive(:upload_data).with(fake_file)
+
+        allow(@cloud).to receive(:wait_resource).with(image, :active)
+
+        @cloud.create_stemcell('/tmp/foo', extra_properties)
+      end
+
+      it 'should throw an error for non existent root image in stemcell archive' do
+        result = Bosh::Exec::Result.new('cmd', 'output', 0)
+        expect(Bosh::Exec).to receive(:sh).and_return(result)
+
+        allow(File).to receive(:exists?).and_return(false)
+
+        expect {
+          @cloud.create_stemcell('/tmp/foo', {
+            'name' => 'stemcell-name',
+            'version' => 'x.y.z',
+            'container_format' => 'bare',
+            'disk_format' => 'qcow2'
+          })
+        }.to raise_exception(Bosh::Clouds::CloudError, 'Root image is missing from stemcell archive')
+      end
+
+      it 'should fail if cannot extract root image' do
+        result = Bosh::Exec::Result.new('cmd', 'output', 1)
+        expect(Bosh::Exec).to receive(:sh).and_return(result)
+
+        expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+
+        expect {
+          @cloud.create_stemcell('/tmp/foo', {
+            'name' => 'stemcell-name',
+            'version' => 'x.y.z',
+            'container_format' => 'ami',
+            'disk_format' => 'ami'
+          })
+        }.to raise_exception(Bosh::Clouds::CloudError,
+          'Extracting stemcell root image failed. Check task debug log for details.')
+      end
+
+      context 'stemcell_public_visibility is true' do
+
+        let(:cloud_options) do
+          cloud_options = mock_cloud_options['properties']
+          cloud_options['openstack']['stemcell_public_visibility'] = true
+          cloud_options
+        end
+
+        it 'sets stemcell visibility to public when required' do
+          image_params = {
+            name: 'stemcell-name/x.y.z',
+            disk_format: 'qcow2',
+            container_format: 'bare',
+            visibility: 'public',
+            version: 'x.y.z',
+          }
+
+          expect(@glance.images).to receive(:create).with(image_params).and_return(image)
+
+          expect(Dir).to receive(:mktmpdir).and_yield(@tmp_dir)
+          expect(@cloud).to receive(:unpack_image).with(@tmp_dir, '/tmp/foo')
+          expect(@cloud).to receive(:wait_resource).with(image, :queued)
+
+          fake_file = double(File)
+          expect(File).to receive(:open).with("#{@tmp_dir}/root.img", 'rb').and_return(fake_file)
+          expect(image).to receive(:upload_data).with(fake_file)
+
+          expect(@cloud).to receive(:wait_resource).with(image, :active)
+
+          sc_id = @cloud.create_stemcell('/tmp/foo', {
+            'name' => 'stemcell-name',
+            'version' => 'x.y.z',
+            'container_format' => 'bare',
+            'disk_format' => 'qcow2',
+          })
+
+          expect(sc_id).to eq 'i-bar'
+        end
+      end
+
+    end
+
   end
 end

--- a/src/bosh_openstack_cpi/spec/unit/create_stemcell_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/create_stemcell_spec.rb
@@ -27,7 +27,7 @@ describe Bosh::OpenStackCloud::Cloud do
           disk_format: 'qcow2',
           container_format: 'bare',
           location: "#{@tmp_dir}/root.img",
-          is_public: 'false',
+          is_public: false,
           properties: {
             version: 'x.y.z'
           }
@@ -55,7 +55,7 @@ describe Bosh::OpenStackCloud::Cloud do
           disk_format: 'qcow2',
           container_format: 'bare',
           location: "#{@tmp_dir}/root.img",
-          is_public: 'false',
+          is_public: false,
           properties: {
             version: 'x.y.z',
             os_type: 'linux',
@@ -106,7 +106,7 @@ describe Bosh::OpenStackCloud::Cloud do
           disk_format: 'qcow2',
           container_format: 'bare',
           location: "#{@tmp_dir}/root.img",
-          is_public: 'false',
+          is_public: false,
           properties: {
             version: 'x.y.z',
             os_type: 'linux',
@@ -170,7 +170,7 @@ describe Bosh::OpenStackCloud::Cloud do
             disk_format: 'qcow2',
             container_format: 'bare',
             location: "#{@tmp_dir}/root.img",
-            is_public: 'true',
+            is_public: true,
             properties: {
               version: 'x.y.z'
             }
@@ -192,7 +192,6 @@ describe Bosh::OpenStackCloud::Cloud do
           expect(sc_id).to eq 'i-bar'
         end
       end
-
     end
 
     context 'when an environment supports image v2' do

--- a/src/bosh_openstack_cpi/spec/unit/delete_stemcell_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/delete_stemcell_spec.rb
@@ -8,7 +8,7 @@ describe Bosh::OpenStackCloud::Cloud do
   it "deletes stemcell" do
     image = double("image", :id => "i-foo", :name => "i-foo", :properties => {})
 
-    cloud = mock_glance do |glance|
+    cloud = mock_glance_v2 do |glance|
       allow(glance.images).to receive(:find_by_id).with("i-foo").and_return(image)
     end
 

--- a/src/bosh_openstack_cpi/spec/unit/openstack_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/openstack_spec.rb
@@ -62,8 +62,8 @@ describe Bosh::OpenStackCloud::Openstack do
 
 
   [ {clazz: Fog::Compute, name: 'Compute', method_name: :compute},
-    {clazz: Fog::Image::OpenStack::V1, name: 'Image', method_name: :image},
-    {clazz: Fog::Volume::OpenStack::V1, name: 'Volume', method_name: :volume},
+    {clazz: Fog::Image::OpenStack::V2, name: 'Image', method_name: :image},
+    {clazz: Fog::Volume::OpenStack::V2, name: 'Volume', method_name: :volume},
     {clazz: Fog::Network, name: 'Network', method_name: :network}
   ].each do | fog |
     describe "#{fog[:name]}" do


### PR DESCRIPTION
- This allows the CPI to interact with Image (Glance) and Volume (Cinder) v2 APIs
- If the OpenStack environment doesn't support V2, the CPI automatically falls back to V1
- Introduces WebMock as a test dependency to force the OpenStack gem into Image/Volume V1 mode even if the environment supports V2
- Removes support for image[:copy_from] which allowed users to specify a remote URL for a stemcell as this feature doesn't exist in Glance V2
  - Confirmed with Marco that this feature was never used by BOSH
- We added a temporary monkeypatch to fog-openstack which can be removed once
  https://github.com/fog/fog-openstack/pull/170 is merged
- Use human-readable image names
  - The image name is cosmetic, we always perform lookups based on image IDs
  - 'bosh-openstack-kvm-ubuntu-trusty-go_agent/3262.5' instead of
    'BOSH-35d7b930-40fb-4a30-9050-edf1689685a1'
- Use newer hash syntax in create_stemcell_spec

Fixes #31.

[#126520625](https://www.pivotaltracker.com/story/show/126520625)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>