### PR TITLE
Use image_resource: instead of image:

### DIFF
--- a/ci/pipelines/certify-stemcell/tasks/deploy-director.yml
+++ b/ci/pipelines/certify-stemcell/tasks/deploy-director.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-cpi-release

--- a/ci/pipelines/certify-stemcell/tasks/deploy-dummy-release-multiple-manual-networks.yml
+++ b/ci/pipelines/certify-stemcell/tasks/deploy-dummy-release-multiple-manual-networks.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: dummy-release

--- a/ci/pipelines/certify-stemcell/tasks/deploy-dummy-release.yml
+++ b/ci/pipelines/certify-stemcell/tasks/deploy-dummy-release.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: dummy-release

--- a/ci/pipelines/certify-stemcell/tasks/deploy-old-director.yml
+++ b/ci/pipelines/certify-stemcell/tasks/deploy-old-director.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: old-bosh-init

--- a/ci/pipelines/certify-stemcell/tasks/generate-certification.yml
+++ b/ci/pipelines/certify-stemcell/tasks/generate-certification.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-release

--- a/ci/pipelines/certify-stemcell/tasks/teardown-director.yml
+++ b/ci/pipelines/certify-stemcell/tasks/teardown-director.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-cpi-release

--- a/ci/pipelines/certify-stemcell/tasks/teardown.yml
+++ b/ci/pipelines/certify-stemcell/tasks/teardown.yml
@@ -1,7 +1,10 @@
 
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-init

--- a/ci/pipelines/certify-stemcell/tasks/test-upgrade.yml
+++ b/ci/pipelines/certify-stemcell/tasks/test-upgrade.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-cpi-release

--- a/ci/tasks/build-candidate.yml
+++ b/ci/tasks/build-candidate.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: version-semver

--- a/ci/tasks/cleanup.yml
+++ b/ci/tasks/cleanup.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
 run:

--- a/ci/tasks/deploy-dynamic-networking.yml
+++ b/ci/tasks/deploy-dynamic-networking.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-init

--- a/ci/tasks/deploy-manual-networking.yml
+++ b/ci/tasks/deploy-manual-networking.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-init

--- a/ci/tasks/promote-candidate.yml
+++ b/ci/tasks/promote-candidate.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-cpi-dev-artifacts

--- a/ci/tasks/publish-api-calls.yml
+++ b/ci/tasks/publish-api-calls.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: lifecycle-log

--- a/ci/tasks/run-dynamic-networking-bats.yml
+++ b/ci/tasks/run-dynamic-networking-bats.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: stemcell

--- a/ci/tasks/run-lifecycle.yml
+++ b/ci/tasks/run-lifecycle.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: openstack-lifecycle-stemcell

--- a/ci/tasks/run-manual-networking-bats.yml
+++ b/ci/tasks/run-manual-networking-bats.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: stemcell

--- a/ci/tasks/teardown-director.yml
+++ b/ci/tasks/teardown-director.yml
@@ -1,6 +1,9 @@
 ---
 platform: linux
-image: docker:///boshcpi/openstack-cpi-release
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/openstack-cpi-release
 inputs:
   - name: bosh-cpi-src-in
   - name: bosh-cpi-dev-artifacts


### PR DESCRIPTION
Concourse standalone does not support the deprecated (?) `image:` syntax.
See https://github.com/concourse/concourse/issues/402