### PR TITLE
add 'default_volume_type' to global CPI config

### DIFF
--- a/jobs/openstack_cpi/spec
+++ b/jobs/openstack_cpi/spec
@@ -61,6 +61,9 @@ properties:
   openstack.default_security_groups:
     description: Default OpenStack security groups to use when spinning up new VMs (required)
     example: [bosh-grp]
+  openstack.default_volume_type:
+    description: Default OpenStack volume type to use when creating new disks (optional)
+    example: SSD
   openstack.wait_resource_poll_interval:
     description: Changes the delay (in seconds) between each status check to OpenStack when creating a resource (optional, by default 5)
     default: 5

--- a/jobs/openstack_cpi/templates/cpi.json.erb
+++ b/jobs/openstack_cpi/templates/cpi.json.erb
@@ -9,6 +9,7 @@
           'api_key' => p('openstack.api_key'),
           'default_key_name' => p('openstack.default_key_name'),
           'default_security_groups' => p('openstack.default_security_groups'),
+          'default_volume_type' => p('openstack.default_volume_type', nil),
           'wait_resource_poll_interval' => p('openstack.wait_resource_poll_interval'),
           'ignore_server_availability_zone' => p('openstack.ignore_server_availability_zone'),
           'use_nova_networking' => p('openstack.use_nova_networking')

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -35,6 +35,7 @@ module Bosh::OpenStackCloud
       openstack_properties = @options['openstack']
       @default_key_name = openstack_properties['default_key_name']
       @default_security_groups = openstack_properties['default_security_groups']
+      @default_volume_type = openstack_properties['default_volume_type']
       @state_timeout = openstack_properties['state_timeout']
       @stemcell_public_visibility = openstack_properties['stemcell_public_visibility']
       @wait_resource_poll_interval = openstack_properties['wait_resource_poll_interval']
@@ -385,6 +386,8 @@ module Bosh::OpenStackCloud
 
         if cloud_properties.has_key?('type')
           volume_params[:volume_type] = cloud_properties['type']
+        elsif !@default_volume_type.nil?
+          volume_params[:volume_type] = @default_volume_type
         end
 
         if server_id  && @az_provider.constrain_to_server_availability_zone?
@@ -875,6 +878,7 @@ module Bosh::OpenStackCloud
                 optional('boot_from_volume') => bool,
                 optional('default_key_name') => String,
                 optional('default_security_groups') => [String],
+                optional('default_volume_type') => String,
                 optional('wait_resource_poll_interval') => Integer,
                 optional('config_drive') => enum('disk', 'cdrom'),
                 optional('human_readable_vm_names') => bool,

--- a/src/bosh_openstack_cpi/spec/integration/integration_config.rb
+++ b/src/bosh_openstack_cpi/spec/integration/integration_config.rb
@@ -60,7 +60,7 @@ class IntegrationConfig
   end
 
 
-  def create_cpi(boot_from_value = false, config_drive = nil, human_readable_vm_names = false, use_nova_networking = false, use_dhcp=true)
+  def create_cpi(boot_from_volume: false, config_drive: nil, human_readable_vm_names: false, use_nova_networking: false, use_dhcp: true, default_volume_type: nil)
     openstack_properties = {'openstack' => {
         'auth_url' => @auth_url,
         'username' => @username,
@@ -69,8 +69,9 @@ class IntegrationConfig
         'endpoint_type' => 'publicURL',
         'default_key_name' => @default_key_name,
         'default_security_groups' => %w(default),
+        'default_volume_type' => default_volume_type,
         'wait_resource_poll_interval' => 5,
-        'boot_from_volume' => boot_from_value,
+        'boot_from_volume' => boot_from_volume,
         'config_drive' => config_drive,
         'use_dhcp'=> use_dhcp,
         'ignore_server_availability_zone' => str_to_bool(@ignore_server_az),

--- a/src/bosh_openstack_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_openstack_cpi/spec/integration/lifecycle_spec.rb
@@ -4,7 +4,7 @@ describe Bosh::OpenStackCloud::Cloud do
   # @formatter:off
   before(:all) do
     @config = IntegrationConfig.new
-    @cpi_for_stemcell = @config.create_cpi(false, nil, false)
+    @cpi_for_stemcell = @config.create_cpi
     @stemcell_id, _ = upload_stemcell(@cpi_for_stemcell, @config.stemcell_path)
   end
   # @formatter:on
@@ -26,7 +26,7 @@ describe Bosh::OpenStackCloud::Cloud do
   let(:use_nova_networking) { false }
 
   subject(:cpi) do
-    @config.create_cpi(boot_from_volume, config_drive, human_readable_vm_names, use_nova_networking, use_dhcp)
+    @config.create_cpi(boot_from_volume: boot_from_volume, config_drive: config_drive, human_readable_vm_names: human_readable_vm_names, use_nova_networking: use_nova_networking, use_dhcp: use_dhcp)
   end
 
   before { allow(Bosh::Cpi::RegistryClient).to receive(:new).and_return(double('registry').as_null_object) }

--- a/src/bosh_openstack_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/bosh_release/jobs/cpi/templates/cpi.json.erb_spec.rb
@@ -77,7 +77,8 @@ describe 'cpi.json.erb' do
             'username' => 'openstack.username',
             'wait_resource_poll_interval' => 'openstack.wait_resource_poll_interval',
             'human_readable_vm_names' => false,
-            'use_nova_networking' => false
+            'use_nova_networking' => false,
+            'default_volume_type' => nil
           },
           'registry' => {
             'address' => 'registry.host',


### PR DESCRIPTION
The disk type is determined in this order (descreasing priority):
- disk_pools.cloud_properties.type
- global_config.openstack.default_volume_type
- default type for entire Cinder installation

This allows the Operator to specify a different default type per Director without
needing permission to change the default type for the entire Cinder installation.

Signed-off-by: Brian Cunnie <bcunnie@pivotal.io>

[#135146373](https://www.pivotaltracker.com/story/show/135146373)

Signed-off-by: Chris Dutra <cdutra@pivotal.io>