### PR TITLE
shared_vip support for vrrp using allowed_address_pairs

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -201,7 +201,10 @@ module Bosh::OpenStackCloud
 
         begin
           @openstack.with_openstack {
-            network_configurator.prepare(@openstack, picked_security_groups.map { |sg| sg.id })
+            network_configurator.prepare(@openstack,
+              picked_security_groups.map { |sg| sg.id },
+              resource_pool['shared_vip'] ? [{ :ip_address => resource_pool['shared_vip'] }] : []
+            )
           }
 
           nics = network_configurator.nics
@@ -724,7 +727,7 @@ module Bosh::OpenStackCloud
 
       nil
     end
-    
+
     private
 
     def mib_to_gib(size)

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/manual_network.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/manual_network.rb
@@ -20,24 +20,25 @@ module Bosh::OpenStackCloud
       @ip
     end
 
-    def prepare(openstack, security_group_ids)
+    def prepare(openstack, security_group_ids, allowed_address_pairs)
       if openstack.use_nova_networking?
         @nic['v4_fixed_ip'] = @ip
       else
         @logger.debug("Creating port for IP #{@ip} in network #{net_id}")
-        port = create_port_for_manual_network(openstack, net_id, @ip, security_group_ids)
+        port = create_port_for_manual_network(openstack, net_id, @ip, security_group_ids, allowed_address_pairs)
         @logger.debug("Port with ID #{port.id} and MAC address #{port.mac_address} created")
         @nic['port_id'] = port.id
         @spec['mac'] = port.mac_address
       end
     end
 
-    def create_port_for_manual_network(openstack, net_id, ip_address, security_group_ids)
+    def create_port_for_manual_network(openstack, net_id, ip_address, security_group_ids, allowed_address_pairs = [])
       openstack.with_openstack {
         openstack.network.ports.create({
             network_id: net_id,
             fixed_ips: [{ip_address: ip_address}],
-            security_groups: security_group_ids
+            security_groups: security_group_ids,
+            allowed_address_pairs: allowed_address_pairs
         })
       }
     end

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/network.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/network.rb
@@ -31,7 +31,7 @@ module Bosh::OpenStackCloud
     def configure(openstack, server)
     end
 
-    def prepare(openstack, security_groups)
+    def prepare(openstack, security_groups, allowed_address_pairs)
     end
 
     def cleanup(openstack)

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/network_configurator.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/network_configurator.rb
@@ -49,9 +49,9 @@ module Bosh::OpenStackCloud
       end
     end
 
-    def prepare(openstack, security_group_ids)
+    def prepare(openstack, security_group_ids, allowed_address_pairs)
       @networks.each do |network|
-        network.prepare(openstack, security_group_ids)
+        network.prepare(openstack, security_group_ids, allowed_address_pairs)
       end
     end
 

--- a/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -146,7 +146,7 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
         allow(openstack.compute.key_pairs).to receive(:find).and_return(key_pair)
         port_result_net = double('ports1', id: '117717c1-81cb-4ac4-96ab-99aaf1be9ca8', network_id: 'net', mac_address: 'AA:AA:AA:AA:AA:AA')
         ports = double('Fog::Network::OpenStack::Ports')
-        allow(ports).to receive(:create).with(network_id: 'net', fixed_ips: [{ip_address: '10.0.0.1'}], security_groups: ['default_sec_group_id']).and_return(port_result_net)
+        allow(ports).to receive(:create).with(network_id: 'net', fixed_ips: [{ip_address: '10.0.0.1'}], security_groups: ['default_sec_group_id'], allowed_address_pairs: []).and_return(port_result_net)
         allow(openstack.network).to receive(:ports).and_return(ports)
       end
     end
@@ -373,7 +373,7 @@ describe Bosh::OpenStackCloud::Cloud, "create_vm" do
     end
 
     it 'calls NetworkConfigurator#prepare and NetworkConfigurator#nics' do
-      expect_any_instance_of(Bosh::OpenStackCloud::NetworkConfigurator).to receive(:prepare).with(anything, ['default_sec_group_id'])
+      expect_any_instance_of(Bosh::OpenStackCloud::NetworkConfigurator).to receive(:prepare).with(anything, ['default_sec_group_id'], [])
       expect_any_instance_of(Bosh::OpenStackCloud::NetworkConfigurator).to receive(:nics).and_return(nics)
 
       cloud.create_vm("agent-id", "sc-id",

--- a/src/bosh_openstack_cpi/spec/unit/network_configurator_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/network_configurator_spec.rb
@@ -160,7 +160,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
       context 'and no port id is available in network spec' do
         let(:openstack) { instance_double(Bosh::OpenStackCloud::Openstack, use_nova_networking?: true) }
         it 'should set fixed ip only' do
-          nc.prepare(openstack, nil)
+          nc.prepare(openstack, nil, nil)
 
           expect(nc.nics).to eq([{'net_id' => 'net', 'v4_fixed_ip' => '10.0.0.1'}])
         end
@@ -174,7 +174,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
         end
 
         it 'should set port id only' do
-          nc.prepare(openstack, nil)
+          nc.prepare(openstack, nil, nil)
 
           expect(nc.nics).to eq([{'net_id' => 'net', 'port_id' => '117717c1-81cb-4ac4-96ab-99aaf1be9ca8'}])
         end
@@ -184,7 +184,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
         let(:openstack) { instance_double(Bosh::OpenStackCloud::Openstack, use_nova_networking?: true) }
         it 'should extract net_id and IP address from all' do
           nc = Bosh::OpenStackCloud::NetworkConfigurator.new(several_manual_networks)
-          nc.prepare(openstack, nil)
+          nc.prepare(openstack, nil, nil)
 
           expect(nc.nics).to eq([
                                     {'net_id' => 'net', 'v4_fixed_ip' => '10.0.0.1'},
@@ -216,7 +216,7 @@ describe Bosh::OpenStackCloud::NetworkConfigurator do
           'network_c' => dynamic_network_spec
       })
 
-      nc.prepare(openstack, [])
+      nc.prepare(openstack, [], [])
 
       networks.each do |network|
         expect(network).to have_received(:prepare)


### PR DESCRIPTION
This PR adds support for vms with a shared_vip.
The main usecase for this is using the [keepalived job](https://github.com/cloudfoundry-incubator/haproxy-boshrelease/tree/master/jobs/keepalived) from the haproxy release, to have vip shared between to haproxy instances using vrrp.

Some additional resources about this usecase:
- [highly available vips on openstack](https://blog.codecentric.de/en/2016/11/highly-available-vips-openstack-vms-vrrp/)
- [Allowed address pairs openstack api docs](https://specs.openstack.org/openstack/neutron-specs/specs/api/allowed_address_pairs.html)
- [fog allowed_address_pair example](https://github.com/fog/fog-openstack/blob/master/examples/network/network_add_port.rb#L19-L20)

Unit tested passed, will now test on our OpenStack, but wanted to already make to PR to open the discussion. And to get feedback on if this usecase is something which would be usefull to support upstream.