### PR TITLE
Moving / to - in VM name and Metadata name

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/cloud.rb
@@ -427,7 +427,7 @@ module Bosh::OpenStackCloud
         metadata.merge!({
           'director' => metadata['director_name'],
           'instance_index' => metadata['index'].to_s,
-          'instance_name' => metadata['job'] + '/' + metadata['instance_id']
+          'instance_name' => metadata['job'] + '-' + metadata['instance_id']
         })
 
         metadata.delete('director_name')
@@ -490,11 +490,11 @@ module Bosh::OpenStackCloud
               @logger.debug("Rename VM with id '#{server_id}' to '#{name}'")
               @openstack.compute.update_server(server_id, {'name' => "#{name}"})
             elsif job && index
-              @logger.debug("Rename VM with id '#{server_id}' to '#{job}/#{index}'")
-              @openstack.compute.update_server(server_id, {'name' => "#{job}/#{index}"})
+              @logger.debug("Rename VM with id '#{server_id}' to '#{job}-#{index}'")
+              @openstack.compute.update_server(server_id, {'name' => "#{job}-#{index}"})
             elsif compiling
-              @logger.debug("Rename VM with id '#{server_id}' to 'compiling/#{compiling}'")
-              @openstack.compute.update_server(server_id, {'name' => "compiling/#{compiling}"})
+              @logger.debug("Rename VM with id '#{server_id}' to 'compiling-#{compiling}'")
+              @openstack.compute.update_server(server_id, {'name' => "compiling-#{compiling}"})
             end
           else
             @logger.debug("VM with id '#{server_id}' has no 'registry_key' tag")

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/loadbalancer_configurator.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/loadbalancer_configurator.rb
@@ -227,4 +227,3 @@ module Bosh::OpenStackCloud
     end
   end
 end
-

--- a/src/bosh_openstack_cpi/spec/integration/lifecycle_spec.rb
+++ b/src/bosh_openstack_cpi/spec/integration/lifecycle_spec.rb
@@ -8,7 +8,7 @@ describe Bosh::OpenStackCloud::Cloud do
     @stemcell_id, _ = upload_stemcell(@cpi_for_stemcell, @config.stemcell_path)
   end
   # @formatter:on
-  
+
   before { allow(Bosh::Clouds::Config).to receive(:logger).and_return(@config.logger) }
 
   after(:all) do
@@ -83,7 +83,7 @@ describe Bosh::OpenStackCloud::Cloud do
 
       it 'sets the vm name according to the metadata' do
         vm = openstack.compute.servers.get(@human_readable_vm_name_id)
-        expect(vm.name).to eq 'openstack_cpi_spec/instance_id'
+        expect(vm.name).to eq 'openstack_cpi_spec-instance_id'
       end
     end
   end
@@ -613,7 +613,7 @@ describe Bosh::OpenStackCloud::Cloud do
     @config.logger.info("Setting VM metadata vm_id=#{vm_id}")
     cpi.set_vm_metadata(vm_id, {
       'deployment' => 'deployment',
-      'name' => 'openstack_cpi_spec/instance_id',
+      'name' => 'openstack_cpi_spec-instance_id',
     })
 
     vm_id

--- a/src/bosh_openstack_cpi/spec/unit/set_vm_metadata_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/set_vm_metadata_spec.rb
@@ -21,7 +21,7 @@ describe Bosh::OpenStackCloud::Cloud do
       @cloud.set_vm_metadata('i-foobar', metadata)
     end
 
-    it "logs 'compiling/x'" do
+    it "logs 'compiling-x'" do
       @cloud.set_vm_metadata("i-foobar", {})
       expect(Bosh::Clouds::Config.logger).to have_received(:debug).with("VM with id 'i-foobar' has no 'registry_key' tag")
     end
@@ -40,14 +40,14 @@ describe Bosh::OpenStackCloud::Cloud do
       context "when bosh provides NO 'name' property" do
         let(:metadata) { {'job' => 'job', 'index' => 'index'} }
 
-        it "sets the vm name 'job/index'" do
+        it "sets the vm name 'job-index'" do
           @cloud.set_vm_metadata("i-foobar", metadata)
-          expect(@cloud.compute).to have_received(:update_server).with('i-foobar', {'name' => 'job/index'})
+          expect(@cloud.compute).to have_received(:update_server).with('i-foobar', {'name' => 'job-index'})
         end
 
         it 'logs job name & index' do
           @cloud.set_vm_metadata("i-foobar", metadata)
-          expect(Bosh::Clouds::Config.logger).to have_received(:debug).with("Rename VM with id 'i-foobar' to 'job/index'")
+          expect(Bosh::Clouds::Config.logger).to have_received(:debug).with("Rename VM with id 'i-foobar' to 'job-index'")
         end
       end
 
@@ -70,14 +70,14 @@ describe Bosh::OpenStackCloud::Cloud do
     context 'for compilation vms' do
       let(:metadata) { {'compiling' => 'x'} }
 
-      it "sets the vm name 'compiling/x'" do
+      it "sets the vm name 'compiling-x'" do
         @cloud.set_vm_metadata("i-foobar", metadata)
-        expect(@cloud.compute).to have_received(:update_server).with('i-foobar', {'name' => 'compiling/x'})
+        expect(@cloud.compute).to have_received(:update_server).with('i-foobar', {'name' => 'compiling-x'})
       end
 
-      it "logs 'compiling/x'" do
+      it "logs 'compiling-x'" do
         @cloud.set_vm_metadata("i-foobar", metadata)
-        expect(Bosh::Clouds::Config.logger).to have_received(:debug).with("Rename VM with id 'i-foobar' to 'compiling/x'")
+        expect(Bosh::Clouds::Config.logger).to have_received(:debug).with("Rename VM with id 'i-foobar' to 'compiling-x'")
       end
     end
   end

--- a/src/bosh_openstack_cpi/spec/unit/snapshot_disk_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/snapshot_disk_spec.rb
@@ -153,7 +153,7 @@ describe Bosh::OpenStackCloud::Cloud do
       'deployment' => 'deployment',
       'instance_id' => 'some-uuid',
       'instance_index' => '0',
-      'instance_name' => 'job/some-uuid',
+      'instance_name' => 'job-some-uuid',
       'agent_id' => 'agent0'
     }
 
@@ -189,7 +189,7 @@ describe Bosh::OpenStackCloud::Cloud do
       'deployment' => 'deployment',
       'instance_id' => 'some-uuid',
       'instance_index' => '0',
-      'instance_name' => 'job/some-uuid',
+      'instance_name' => 'job-some-uuid',
       'agent_id' => 'agent0',
       'tag1' => 'value1',
       'tag2' => 'value2'


### PR DESCRIPTION
Putting "/" in vm name and metadata name could create some issue , of course we can disable human readable.  But I wanted something more generic and allowing the vm to be somehow human readable.


So this PR just change "/" by "-". I run the unit test and everythings pass, but I may miss some important change.

Thanks