### PR TITLE
Update security_groups.rb (#1)

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/security_groups.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/security_groups.rb
@@ -40,8 +40,8 @@ module Bosh::OpenStackCloud
 
     def self.map_to_security_groups_in_openstack(picked_security_groups, openstack_security_groups)
       picked_security_groups.map do |configured_sg|
-        openstack_security_group = openstack_security_groups.find {|openstack_sg| openstack_sg.id == configured_sg}
-        openstack_security_group = openstack_security_groups.find {|openstack_sg| openstack_sg.name == configured_sg} unless openstack_security_group
+        openstack_security_group = openstack_security_groups.find {|openstack_sg| openstack_sg.name == configured_sg}
+        openstack_security_group = openstack_security_groups.find {|openstack_sg| openstack_sg.id == configured_sg} unless openstack_security_group
         cloud_error("Security group `#{configured_sg}' not found") unless openstack_security_group
         openstack_security_group
       end

--- a/src/bosh_openstack_cpi/lib/cloud/openstack/security_groups.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/security_groups.rb
@@ -40,7 +40,8 @@ module Bosh::OpenStackCloud
 
     def self.map_to_security_groups_in_openstack(picked_security_groups, openstack_security_groups)
       picked_security_groups.map do |configured_sg|
-        openstack_security_group = openstack_security_groups.find {|openstack_sg| openstack_sg.name == configured_sg}
+        openstack_security_group = openstack_security_groups.find {|openstack_sg| openstack_sg.id == configured_sg}
+        openstack_security_group = openstack_security_groups.find {|openstack_sg| openstack_sg.name == configured_sg} unless openstack_security_group
         cloud_error("Security group `#{configured_sg}' not found") unless openstack_security_group
         openstack_security_group
       end


### PR DESCRIPTION
Hello dear Maintainers,

I always liked the Idea of being able to use actual secGrpIds instead of secGrpNames. The reason behind this is:
I'm using the same account for multiple tenants and would like to have the same secGrpNames within those tenants. Currently my deployments would fail as the code I would like to change will return multiple secGrps.
The background here is that I would like deploy base tenant templates that include a BUCC and some other stuff to bootstrap development / enable teams with their own BUCC.. I'm creating cloud-config, deployment.yml etc on the fly by injecting names/ids etc. via cloud-init onto the jumphosts. These jumphosts then deploy BUCC and already have the basic ymls to build on. The workaround currently is to have a PREFIX attached to the secGrpNames on a tenant basis.

By adding the possibility to use actual secGrpIds alongside secGrpNames, this would help a lot to get rid of some unnecessary code.

Fog seems to support this for compute as well as Network secGrps
https://github.com/fog/fog-openstack/blob/master/lib/fog/compute/openstack/models/security_group.rb#L7
https://github.com/fog/fog-openstack/blob/master/lib/fog/network/openstack/models/security_group.rb#L7


As far as my shitty understanding of ruby goes, that extra line would not even break current behaviour.


This is neither tested, nor am I sure that it works like I'm expecting it to. I would just like to start that discussion and provide some input.
Thank you for reading. :)
thank you @rkoster for supporting me in researching this and finding my way around the cpi code