### PR TITLE
Better error message in case of different AZs for disks and/or VMs

### DIFF
--- a/src/bosh_openstack_cpi/lib/cloud/openstack/availability_zone_provider.rb
+++ b/src/bosh_openstack_cpi/lib/cloud/openstack/availability_zone_provider.rb
@@ -9,10 +9,7 @@ module Bosh::OpenStackCloud
 
     def select(volume_ids, resource_pool_az)
       if volume_ids_not_empty?(volume_ids) && use_server_availability_zone?
-        azs = volume_azs(volume_ids)
-        azs << resource_pool_az if resource_pool_az
-        ensure_one_availability_zone(azs)
-        azs.first.nil? || azs.first.empty? ? nil : azs.first
+        ensure_same_availability_zone(volume_ids, resource_pool_az)
       else
         resource_pool_az
       end
@@ -28,15 +25,34 @@ module Bosh::OpenStackCloud
       volume_ids && !volume_ids.empty?
     end
 
-    def volume_azs(volume_ids)
+    def ensure_same_availability_zone(volume_ids, resource_pool_az)
       fog_volume_map = @openstack.volume.volumes
       volumes = volume_ids.map { |vid| @openstack.with_openstack { fog_volume_map.get(vid) } }
-      volumes.map(&:availability_zone)
+      azs = volumes.map(&:availability_zone)
+      azs << resource_pool_az if resource_pool_az
+
+      uniq_azs = azs.uniq
+      if uniq_azs.size > 1
+        cloud_error format("can't use multiple availability zones: %s, %s. " +
+                           "Enable 'openstack.ignore_server_availability_zone' to allow VMs and disks to be in different AZs, or use the same AZ for both.",
+                           resource_pool_az_description(resource_pool_az), disk_az_description(volumes))
+      else
+        uniq_azs.first.nil? || uniq_azs.first.empty? ? nil : uniq_azs.first
+      end
     end
 
-    def ensure_one_availability_zone(azs)
-      uniq_azs = azs.uniq
-      cloud_error format("can't use multiple availability zones: %s", uniq_azs.join(', ')) unless uniq_azs.size == 1
+    def resource_pool_az_description(resource_pool_az)
+      if resource_pool_az
+        format("VM is created in AZ '%s'", resource_pool_az)
+      else
+        'VM is created in default AZ'
+      end
+    end
+
+    def disk_az_description(volumes)
+      volumes.map do |volume|
+        format("disk '%s' is in AZ '%s'", volume.id, volume.availability_zone)
+      end.join(', ')
     end
   end
 end

--- a/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
+++ b/src/bosh_openstack_cpi/spec/unit/create_vm_spec.rb
@@ -678,8 +678,8 @@ describe Bosh::OpenStackCloud::Cloud, 'create_vm' do
   end
 
   describe 'failing to select an AZ' do
-    let(:volume_foo) { double('volume', availability_zone: 'foo') }
-    let(:volume_bar) { double('volume', availability_zone: 'bar') }
+    let(:volume_foo) { double('volume', id: 'foo_id', availability_zone: 'foo') }
+    let(:volume_bar) { double('volume', id: 'bar_id', availability_zone: 'bar') }
 
     it 'should raise an error when the disks are from different zones' do
       allow(cloud.volume.volumes).to receive(:get).and_return(volume_foo, volume_bar)


### PR DESCRIPTION
If there are different AZs for disks and/or VMs we list all disk ids
with corresponding AZs explicitly.
Additionally, we provide a hint for 'openstack.ignore_server_availability_zone'
in case the user uses different AZs by intent.

[#156221894](https://www.pivotaltracker.com/story/show/156221894)