### PR TITLE
Revert "Bump packages"

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -1,16 +1,16 @@
-ruby_openstack_cpi/bundler-1.16.3.gem:
-  size: 353792
-  object_id: b8469a9f-4007-4890-5746-fd1a8d39772d
-  sha: ca6a670c29d2928a8dca24ee95a7978c8a532e36
-ruby_openstack_cpi/ruby-2.5.1.tar.gz:
-  size: 15923244
-  object_id: dd16c692-8d3d-4ec7-4911-0337ee8177b9
-  sha: 93fafd57a724974b951957c522cdc4478a6bdc2e
-ruby_openstack_cpi/rubygems-2.7.7.tar.gz:
-  size: 915847
-  object_id: 5c11e0f0-125c-4127-7c5a-2e7cb94c8d42
-  sha: 2ee981e5e8331071b29e7599f9b45ae2d79ed975
-ruby_openstack_cpi/yaml-0.2.1.tar.gz:
-  size: 599727
-  object_id: a894f685-6c4a-413b-4e3a-6743bc0de680
-  sha: 125a3113681f06320dcdfde48bab47cba9031263
+ruby_openstack_cpi/bundler-1.16.1.gem:
+  size: 349696
+  object_id: 7d8ecade-c12c-45f5-71fe-353ce423ae75
+  sha: bca8cd6a0d44524c55a04256307da33e6fe37d5f
+ruby_openstack_cpi/ruby-2.4.3.tar.gz:
+  size: 14178729
+  object_id: 096bfdb3-06ce-4df3-5e77-2bdd2adba518
+  sha: 787b7f4e90fb4b39a61bc1a31eb7765f875a590c
+ruby_openstack_cpi/rubygems-2.7.3.tar.gz:
+  size: 849187
+  object_id: 92a1fa6f-1028-4412-5fce-023f58c11044
+  sha: 0f2b8ca36246eb8fa2c5e6b555ae3202fdf3e998
+ruby_openstack_cpi/yaml-0.1.7.tar.gz:
+  size: 527518
+  object_id: b13b05ca-7f83-4dcb-535d-8881295c67b6
+  sha: 3590cbf092ef4c71bc0a9b404c00a626b1e04dee

--- a/packages/ruby_openstack_cpi/packaging
+++ b/packages/ruby_openstack_cpi/packaging
@@ -13,8 +13,8 @@ if [ $openssl_major_version == 0 ]; then
 fi
 
 echo "Installing yaml"
-tar xzf ruby_openstack_cpi/yaml-0.2.1.tar.gz
-pushd yaml-0.2.1 > /dev/null
+tar xzf ruby_openstack_cpi/yaml-0.1.7.tar.gz
+pushd yaml-0.1.7 > /dev/null
   if [ `uname -m` == "ppc64le" ]; then
     CFLAGS='-fPIC' ./configure --build=ppc64le --prefix=${BOSH_INSTALL_TARGET} --disable-shared
   else
@@ -25,17 +25,17 @@ pushd yaml-0.2.1 > /dev/null
 popd > /dev/null
 
 echo "Installing ruby"
-tar xzf ruby_openstack_cpi/ruby-2.5.1.tar.gz
-pushd ruby-2.5.1 > /dev/null
+tar xzf ruby_openstack_cpi/ruby-2.4.3.tar.gz
+pushd ruby-2.4.3 > /dev/null
   LDFLAGS="-Wl,-rpath -Wl,${BOSH_INSTALL_TARGET}" CFLAGS='-fPIC' ./configure --prefix=${BOSH_INSTALL_TARGET} --disable-install-doc --with-opt-dir=/usr/local/opt/openssl:${BOSH_INSTALL_TARGET}
   make
   make install
 popd > /dev/null
 
 echo "Installing rubygems"
-tar zxvf ruby_openstack_cpi/rubygems-2.7.7.tar.gz
-pushd rubygems-2.7.7
+tar zxvf ruby_openstack_cpi/rubygems-2.7.3.tar.gz
+pushd rubygems-2.7.3
   ${BOSH_INSTALL_TARGET}/bin/ruby setup.rb
 popd > /dev/null
 
-${BOSH_INSTALL_TARGET}/bin/gem install ruby_openstack_cpi/bundler-1.16.3.gem --local --no-ri --no-rdoc --force
+${BOSH_INSTALL_TARGET}/bin/gem install ruby_openstack_cpi/bundler-1.16.1.gem --local --no-ri --no-rdoc --force

--- a/packages/ruby_openstack_cpi/spec
+++ b/packages/ruby_openstack_cpi/spec
@@ -1,7 +1,7 @@
 ---
 name: ruby_openstack_cpi
 files:
-- ruby_openstack_cpi/yaml-0.2.1.tar.gz
-- ruby_openstack_cpi/ruby-2.5.1.tar.gz
-- ruby_openstack_cpi/rubygems-2.7.7.tar.gz
-- ruby_openstack_cpi/bundler-1.16.3.gem
+- ruby_openstack_cpi/yaml-0.1.7.tar.gz
+- ruby_openstack_cpi/ruby-2.4.3.tar.gz
+- ruby_openstack_cpi/rubygems-2.7.3.tar.gz
+- ruby_openstack_cpi/bundler-1.16.1.gem


### PR DESCRIPTION
Reverts cloudfoundry-incubator/bosh-openstack-cpi-release#144

ruby 2.5.1 breaks our cpi